### PR TITLE
Update Licensing Information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 
+Copyright (c) 2017, ELIFE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/neet/__init__.py
+++ b/neet/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2017 ELIFE. All rights reserved.
+# Use of this source code is governed by a MIT
+# license that can be found in the LICENSE file.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2017 ELife-ASU. All rights reserved.
+# Copyright 2017 ELIFE. All rights reserved.
 # Use of this source code is governed by a MIT
 # license that can be found in the LICENSE file.
 


### PR DESCRIPTION
The default license file, generated by GitHub, did not include an
attribution. We added attribution to ELIFE and updated the source
file copyright headers to reflect this change.