### PR TITLE
Implement basic state pinning for WTNetworks

### DIFF
--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -158,7 +158,7 @@ class WTNetwork(object):
                 raise(ValueError("invalid node state in states"))
         return True
 
-    def _unsafe_update(self, states, index=None):
+    def _unsafe_update(self, states, index=None, pin=None):
         """
         Update ``states``, in place, according to the network update rules
         without checking the validity of the arguments.
@@ -205,16 +205,23 @@ class WTNetwork(object):
         :type index: int or None
         :returns: the updated states
         """
+        pin_states = pin is not None and pin != []
         if index is None:
+            if pin_states:
+                pinned = np.asarray(states)[pin]
             temp = np.dot(self.weights, states) - self.thresholds
-            return self.theta(temp, states)
+            self.theta(temp, states)
+            if pin_states:
+                for (j,i) in enumerate(pin):
+                    states[i] = pinned[j]
+            return states
         else:
             temp = np.dot(self.weights[index], states) - self.thresholds[index]
             states[index] = self.theta(temp, states[index])
             return states
 
 
-    def update(self, states, index=None):
+    def update(self, states, index=None, pin=None):
         """
         Update ``states``, in place, according to the network update rules.
 
@@ -267,7 +274,7 @@ class WTNetwork(object):
         :raises IndexError: if ``index is not None and index > len(states)``
         """
         self.check_states(states)
-        return self._unsafe_update(states, index)
+        return self._unsafe_update(states, index, pin)
 
     @staticmethod
     def read(nodes_file, edges_file):

--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -163,7 +163,7 @@ class WTNetwork(object):
         Update ``states``, in place, according to the network update rules
         without checking the validity of the arguments.
 
-        .. rubric:: Examples:
+        .. rubric:: Basic Use:
 
         ::
 
@@ -176,15 +176,33 @@ class WTNetwork(object):
             >>> net._unsafe_update(xs)
             [0, 1, 1, 1, 0, 0, 1, 0, 0]
 
+        .. rubric:: Single-Node Update:
+
         ::
 
             >>> xs = [0,0,0,0,1,0,0,0,0]
-            >>> net._unsafe_update(xs, -1)
+            >>> net._unsafe_update(xs, index=-1)
             [0, 0, 0, 0, 1, 0, 0, 0, 1]
-            >>> net._unsafe_update(xs, 2)
+            >>> net._unsafe_update(xs, index=2)
             [0, 0, 1, 0, 1, 0, 0, 0, 1]
-            >>> net._unsafe_update(xs, 3)
+            >>> net._unsafe_update(xs, index=3)
             [0, 0, 1, 1, 1, 0, 0, 0, 1]
+
+
+        .. rubric:: State Pinning:
+
+        ::
+
+            >>> net._unsafe_update([0,0,0,0,1,0,0,0,0], pin=[-1])
+            [0, 0, 0, 0, 0, 0, 0, 0, 0]
+            >>> net._unsafe_update([0,0,0,0,0,0,0,0,1], pin=[1])
+            [0, 0, 1, 1, 0, 0, 1, 0, 0]
+            >>> net._unsafe_update([0,0,0,0,0,0,0,0,1], pin=range(1,4))
+            [0, 0, 0, 0, 0, 0, 1, 0, 0]
+            >>> net._unsafe_update([0,0,0,0,0,0,0,0,1], pin=[1,2,3,-1])
+            [0, 0, 0, 0, 0, 0, 1, 0, 1]
+
+        .. rubric:: Erroneous Usage:
 
         ::
 
@@ -198,11 +216,17 @@ class WTNetwork(object):
             Traceback (most recent call last):
                 ...
             IndexError: index 9 is out of bounds for axis 0 with size 9
+            >>> net._unsafe_update([0,0,0,0,0,0,0,0,1], pin=[10])
+            Traceback (most recent call last):
+                ...
+            IndexError: index 10 is out of bounds for axis 1 with size 9
 
         :param states: the one-dimensional sequence of node states
         :type states: sequence
         :param index: the index to update or None
         :type index: int or None
+        :param pin: the indices to pin (fix to their current state) or None
+        :type pin: sequence
         :returns: the updated states
         """
         pin_states = pin is not None and pin != []
@@ -225,7 +249,7 @@ class WTNetwork(object):
         """
         Update ``states``, in place, according to the network update rules.
 
-        .. rubric:: Examples:
+        .. rubric:: Basic Use:
 
         ::
 
@@ -238,15 +262,32 @@ class WTNetwork(object):
             >>> net.update(xs)
             [0, 1, 1, 1, 0, 0, 1, 0, 0]
 
+        .. rubric:: Single-Node Update:
+
         ::
 
             >>> xs = [0,0,0,0,1,0,0,0,0]
-            >>> net.update(xs, -1)
+            >>> net.update(xs, index=-1)
             [0, 0, 0, 0, 1, 0, 0, 0, 1]
-            >>> net.(xs, 2)
+            >>> net.(xs, index=2)
             [0, 0, 1, 0, 1, 0, 0, 0, 1]
-            >>> net.(xs, 3)
+            >>> net.(xs, index=3)
             [0, 0, 1, 1, 1, 0, 0, 0, 1]
+
+        .. rubric:: State Pinning:
+
+        ::
+
+            >>> net.update([0,0,0,0,1,0,0,0,0], pin=[-1])
+            [0, 0, 0, 0, 0, 0, 0, 0, 0]
+            >>> net.update([0,0,0,0,0,0,0,0,1], pin=[1])
+            [0, 0, 1, 1, 0, 0, 1, 0, 0]
+            >>> net.update([0,0,0,0,0,0,0,0,1], pin=range(1,4))
+            [0, 0, 0, 0, 0, 0, 1, 0, 0]
+            >>> net.update([0,0,0,0,0,0,0,0,1], pin=[1,2,3,-1])
+            [0, 0, 0, 0, 0, 0, 1, 0, 1]
+
+        .. rubric:: Erroneous Usage:
 
         ::
 
@@ -262,16 +303,28 @@ class WTNetwork(object):
             Traceback (most recent call last):
                 ...
             IndexError: index 9 is out of bounds for axis 0 with size 9
+            >>> net.update([0,0,0,0,1,0,0,0,0], index=-1, pin=[-1])
+            Traceback (most recent call last):
+                ...
+            ValueError: cannot provide both the index and pin arguments
+            >>> net.update([0,0,0,0,1,0,0,0,0], pin=[10])
+            Traceback (most recent call last):
+                ...
+            IndexError: index 10 is out of bounds for axis 1 with size 9
 
         :param states: the one-dimensional sequence of node states
         :type states: sequence
         :param index: the index to update (or None)
         :type index: int or None
+        :param pin: the indices to pin (or None)
+        :type pin: sequence
         :returns: the updated states
         :raises TypeError: if ``states`` is not iterable
         :raises ValueError: if ``len(states)`` is not the number of nodes in the network
         :raises ValueError: if ``states[i] not in [0,1]`` for any node ``i``
         :raises IndexError: if ``index is not None and index > len(states)``
+        :raises ValueError: if both ``index`` and ``pin`` are provided
+        :raises IndexError: if any element of ``pin`` is greater than ``len(states)``
         """
         self.check_states(states)
 

--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -274,6 +274,10 @@ class WTNetwork(object):
         :raises IndexError: if ``index is not None and index > len(states)``
         """
         self.check_states(states)
+
+        if (index is not None) and (pin is not None and pin != []):
+            raise(ValueError("cannot provide both the index and pin arguments"))
+
         return self._unsafe_update(states, index, pin)
 
     @staticmethod

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -539,3 +539,19 @@ class TestWTNetwork(unittest.TestCase):
         }
         for x, s in test:
             self.assertEqual(test[(x,s)], bnet.WTNetwork.positive_threshold(x,s))
+
+    def test_update_pin_none(self):
+        net = bnet.WTNetwork([[1,0],[-1,1]], [0.5,0.0],
+          theta=bnet.WTNetwork.positive_threshold)
+        xs = [0,0]
+        self.assertEqual([0,1], net.update(xs, pin=None))
+        xs = [0,0]
+        self.assertEqual([0,1], net.update(xs, pin=[]))
+
+    def test_update_pin(self):
+        net = bnet.WTNetwork([[1,0],[-1,1]], [0.5,0.0],
+          theta=bnet.WTNetwork.positive_threshold)
+        xs = [1,1]
+        self.assertEqual([1,0], net.update(xs, pin=[0]))
+        xs = [0,0]
+        self.assertEqual([0,0], net.update(xs, pin=[1]))

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -548,6 +548,18 @@ class TestWTNetwork(unittest.TestCase):
         xs = [0,0]
         self.assertEqual([0,1], net.update(xs, pin=[]))
 
+
+    def test_update_pin_index_clash(self):
+        net = bnet.WTNetwork([[1,0],[-1,1]], [0.5,0.0],
+          theta=bnet.WTNetwork.positive_threshold)
+        with self.assertRaises(ValueError):
+          net.update([0,0], index=0, pin=[1])
+        with self.assertRaises(ValueError):
+          net.update([0,0], index=1, pin=[1])
+        with self.assertRaises(ValueError):
+          net.update([0,0], index=1, pin=[0,1])
+
+
     def test_update_pin(self):
         net = bnet.WTNetwork([[1,0],[-1,1]], [0.5,0.0],
           theta=bnet.WTNetwork.positive_threshold)

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -570,3 +570,22 @@ class TestWTNetwork(unittest.TestCase):
         net.theta = bnet.WTNetwork.positive_threshold
         xs = [0,0]
         self.assertEqual([0,0], net.update(xs, pin=[1]))
+
+    def test_pinning_s_pombe(self):
+        from neet.boolean.examples import s_pombe
+        self.assertEqual(
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+            s_pombe.update([0,0,0,0,1,0,0,0,0], pin=[-1])
+        )
+        self.assertEqual(
+            [0, 0, 1, 1, 0, 0, 1, 0, 0],
+            s_pombe.update([0,0,0,0,0,0,0,0,1], pin=[1])
+        )
+        self.assertEqual(
+            [0, 0, 0, 0, 0, 0, 1, 0, 0],
+            s_pombe.update([0,0,0,0,0,0,0,0,1], pin=range(1,4))
+        )
+        self.assertEqual(
+            [0, 0, 0, 0, 0, 0, 1, 0, 1],
+            s_pombe.update([0,0,0,0,0,0,0,0,1], pin=[1,2,3,-1])
+        )

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -561,9 +561,12 @@ class TestWTNetwork(unittest.TestCase):
 
 
     def test_update_pin(self):
-        net = bnet.WTNetwork([[1,0],[-1,1]], [0.5,0.0],
-          theta=bnet.WTNetwork.positive_threshold)
+        net = bnet.WTNetwork([[1,0],[-1,1]], [0.5,0.0])
+
+        net.theta = bnet.WTNetwork.negative_threshold
         xs = [1,1]
         self.assertEqual([1,0], net.update(xs, pin=[0]))
+
+        net.theta = bnet.WTNetwork.positive_threshold
         xs = [0,0]
         self.assertEqual([0,0], net.update(xs, pin=[1]))


### PR DESCRIPTION
This commit extends the `update` and `_unsafe_update` methods of `WTNetworks` with an optional argument `pin`. The argument provided should be a sequence (likely a list or NumPy array) of indices to "pin" to their current values. This is, effectively, the same as updating the state and then resetting the nodes specified by `pin` to their previous state.

This pull request partially addresses issue #18.