### PR TITLE
Include data files for boolean networks in installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     license=license,
     requires=['numpy','networkx'],
     packages=['neet', 'neet.boolean'],
+    package_data={'neet.boolean': ['data/*.txt', 'data/*.dat']},
     test_suite='test',
     platforms=['Windows', 'OS X', 'Linux']
 )


### PR DESCRIPTION
Add example files as `package_data`. The example data files in neet.boolean were not being installed. We added those files to the setup script.