### PR TITLE
Improved Performance

### DIFF
--- a/neet/asynchronous.py
+++ b/neet/asynchronous.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a MIT
 # license that can be found in the LICENSE file.
 import copy
+from collections import defaultdict
 from .interfaces import is_network, is_fixed_sized
 
 def transitions(net, size=None, require_update=False, encoded=False):
@@ -29,25 +30,29 @@ def transitions(net, size=None, require_update=False, encoded=False):
         raise ValueError("must provide a size if network is variable-sized")
 
     for state in state_space:
-        count = 0
-        next_states = dict()
-        encoded_states = dict()
-        for node in range(size):
+        next_states = defaultdict(float)
+
+        node, count = 0, 0
+
+        next_state = copy.copy(state)
+        net.update(next_state, index=node)
+        state_code = tuple(next_state)
+        if (not require_update) or next_state[node] != state[node]:
+            next_states[state_code] += 1.0
+            count += 1
+
+        for node in range(1,size):
             next_state = copy.copy(state)
-            net.update(next_state, index=node)
-            state_code = state_space.encode(next_state)
+            net._unsafe_update(next_state, index=node)
+            state_code = tuple(next_state)
             if (not require_update) or next_state[node] != state[node]:
-                if state_code in next_states:
-                    next_states[state_code] += 1.0
-                else:
-                    next_states[state_code] = 1.0
-                    encoded_states[state_code] = next_state
+                next_states[state_code] += 1.0
                 count += 1
 
         if encoded:
-            states = list(next_states.keys())
+            states = [state_space._unsafe_encode(state) for state in next_states.keys()]
         else:
-            states = [encoded_states[state] for state in next_states.keys()]
+            states = [list(state) for state in next_states.keys()]
 
         probabilities = [n / count for n in next_states.values()]
 

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -111,9 +111,9 @@ def transitions(net, size=None, encode=False):
         state_space = net.state_space(size)
 
     for state in state_space:
-        net.update(state)
+        net._unsafe_update(state)
         if encode:
-            yield state_space.encode(state)
+            yield state_space._unsafe_encode(state)
         else:
             yield state
 

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -50,14 +50,22 @@ def trajectory(net, state, timesteps=1, encode=False):
         else:
             state_space = net.state_space(len(state))
 
-        yield state_space.encode(state)
-        for _ in range(timesteps):
-            net.update(state)
-            yield state_space.encode(state)
+        yield state_space._unsafe_encode(state)
+
+        net.update(state)
+        yield state_space._unsafe_encode(state)
+
+        for _ in range(1,timesteps):
+            net._unsafe_update(state)
+            yield state_space._unsafe_encode(state)
     else:
         yield copy.copy(state)
-        for _ in range(timesteps):
-            net.update(state)
+
+        net.update(state)
+        yield copy.copy(state)
+
+        for _ in range(1, timesteps):
+            net._unsafe_update(state)
             yield copy.copy(state)
 
 def transitions(net, size=None, encode=False):

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -291,8 +291,14 @@ def timeseries(net, timesteps, size=None):
     shape = (state_space.ndim, state_space.volume, timesteps+1)
     series = np.empty(shape, dtype=np.int)
 
+    trans = list(transitions(net, size=size, encode=False))
+    encoded_trans = [state_space._unsafe_encode(state) for state in trans]
+
     for (index, init) in enumerate(state_space):
-        traj = trajectory(net, init, timesteps=timesteps, encode=False)
-        for (time, state) in enumerate(traj):
-            series[:, index, time] = state
+        k = index
+        series[:, index, 0] = init[:]
+        for time in range(1, timesteps + 1):
+            series[:, index, time] = trans[k][:]
+            k = encoded_trans[k]
+
     return series


### PR DESCRIPTION
We have made several performance improvements which have reduced the runtime for the test suite by approximately 54%. The greatest improvement comes from the use of `synchronous.transitions` instead of `synchronous.trajectory` within `synchronous.timeseries`. This allows us to use the transitions array as a lookup table and thus only compute the state updates once for each state in the network.