### PR TITLE
Sensitivity fix

### DIFF
--- a/neet/sensitivity.py
+++ b/neet/sensitivity.py
@@ -15,6 +15,9 @@ def sensitivity(net, state):
         http://doi.org/10.1103/PhysRevLett.93.048701
 
     The sensitivity of a Boolean function f on state vector x is the number of Hamming neighbors of x on which the function value is different than on x.
+    
+    This calculates the average sensitivity over all N boolean functions, 
+    where N is the size of net.
 
     .. rubric:: Examples
 
@@ -22,7 +25,7 @@ def sensitivity(net, state):
 
         >>> from neet.boolean.examples import s_pombe
         >>> sensitivity(s_pombe,[0,0,0,0,0,1,1,1,1])
-        7
+        7 (XXX update)
 
     net    : NEET boolean network
     state  : A single network state, represented as a list of node states
@@ -36,15 +39,19 @@ def sensitivity(net, state):
 
     nextState = net.update(state)
 
-    # count number of neighbors that update to a different state than original
+    # count sum of differences found in neighbors of the original
     s = 0
     for neighbor in neighbors:
         newState = net.update(neighbor)
-        if not np.array_equal(newState, nextState):
-            s += 1
+        s += boolean_distance(newState, nextState)
 
-    return s
+    return s / net.size
 
+def boolean_distance(state1,state2):
+    """
+    Boolean distance between two states.
+    """
+    return np.sum(abs(np.array(state1)-np.array(state2)))
 
 def hamming_neighbors(state):
     """

--- a/neet/sensitivity.py
+++ b/neet/sensitivity.py
@@ -24,8 +24,8 @@ def sensitivity(net, state):
     ::
 
         >>> from neet.boolean.examples import s_pombe
-        >>> sensitivity(s_pombe,[0,0,0,0,0,1,1,1,1])
-        7 (XXX update)
+        >>> sensitivity(s_pombe,[0,0,0,0,0,1,1,0,0])
+        1.0
 
     net    : NEET boolean network
     state  : A single network state, represented as a list of node states
@@ -40,7 +40,7 @@ def sensitivity(net, state):
     nextState = net.update(state)
 
     # count sum of differences found in neighbors of the original
-    s = 0
+    s = 0.
     for neighbor in neighbors:
         newState = net.update(neighbor)
         s += boolean_distance(newState, nextState)
@@ -95,18 +95,18 @@ def average_sensitivity(net, states=None, weights=None):
 
     ::
 
-        >>> from neet.boolean.examples import s_pombe
-        >>> average_sensitivity(s_pombe)
-        6.0
+        >>> from neet.boolean.examples import c_elegans
+        >>> average_sensitivity(c_elegans)
+        1.265625
+        >>> average_sensitivity(c_elegans,states=[[0,0,0,0,0,0,0,0],
+        [1,1,1,1,1,1,1,1]])
+        1.5
+        >>> average_sensitivity(c_elegans,states=[[0,0,0,0,0,0,0,0],
+        [1,1,1,1,1,1,1,1]],weights=[0.9,0.1])
+        1.7
         >>> average_sensitivity(s_pombe,states=[[0,0,0,0,0,0,0,0,0],
-        [0,1,0,1,0,1,0,1,0]])
-        5.5
-        >>> average_sensitivity(s_pombe,states=[[0,0,0,0,0,0,0,0,0],
-        [0,1,0,1,0,1,0,1,0]],weights=[0.9,0.1])
-        3.75
-        >>> average_sensitivity(s_pombe,states=[[0,0,0,0,0,0,0,0,0],
-        [0,1,0,1,0,1,0,1,0]],weights=[9,1])
-        3.75
+        [1,1,1,1,1,1,1,1]],weights=[9,1])
+        1.7
 
     net    : NEET boolean network
     states : Optional list or generator of states.  If None, all states are used.
@@ -133,7 +133,7 @@ def average_sensitivity(net, states=None, weights=None):
         sensList.append(sensitivity(net, state))
 
     if weights is not None:
-        sensList = 1. / np.sum(weights) * \
+        sensList = 1. * len(sensList) / np.sum(weights) * \
             np.array(weights) * np.array(sensList)
 
     return np.mean(sensList)

--- a/test/test_sensitivity.py
+++ b/test/test_sensitivity.py
@@ -49,7 +49,7 @@ class TestSensitivityWTNetwork(unittest.TestCase):
 
     def test_sensitivity(self):
         net = NB.WTNetwork([[1, -1], [0, 1]], [0.5, 0])
-        self.assertEqual(2, sensitivity(net, [0, 0]))
+        self.assertEqual(1.0, sensitivity(net, [0, 0]))
 
     def test_average_sensitivity_net_type(self):
         with self.assertRaises(TypeError):
@@ -67,4 +67,4 @@ class TestSensitivityWTNetwork(unittest.TestCase):
 
     def test_average_sensitivity(self):
         net = NB.WTNetwork([[1, -1], [0, 1]], [0.5, 0])
-        self.assertEqual(1.5, average_sensitivity(net))
+        self.assertEqual(1.0, average_sensitivity(net))


### PR DESCRIPTION
The previous sensitivity calculation was incorrect and is now fixed.  

The old way interpreted a boolean function as having an output that is an entire binary vector, and counted the number of hamming neighbors that produced output that was different in any way.  The definition in Shmulevich and Kauffman's paper was instead intended for functions with a single binary output, corresponding to each node in our networks.  

So we instead want the average sensitivity over nodes, which corresponds to summing the hamming distances (between the original output network state and the output network state starting from hamming neighbors) and dividing by the number of nodes.

This is all still implemented rather naively and could likely be made much faster.

This would close issue #62 .