### PR TITLE
Add metadata for boolean networks

### DIFF
--- a/neet/boolean/examples.py
+++ b/neet/boolean/examples.py
@@ -62,7 +62,7 @@ p53_no_dmg = WTNetwork.read(P53_NO_DMG_NODES, P53_NO_DMG_EDGES)
 p53_no_dmg.metadata.update( {
     'name': 'p53_no_dmg',
     'description': 'The p53 GRN with no damage present.',
-    'citation': '',
+    'citation': 'Choi, Minsoo, Jue Shi, Sung Hoon Jung, Xi Chen, and Kwang-Hyun Cho. Attractor Landscape Analysis Reveals Feedback Loops in the p53 Network That Control the Cellular Response to DNA Damage. Science Signaling 5, no. 251 (2012): ra83. doi:10.1126/scisignal.2003363.',
     } )
 
 # Get the path of the nodes and edges files for the p53 GRN w/damage
@@ -75,7 +75,7 @@ p53_dmg = WTNetwork.read(P53_DMG_NODES, P53_DMG_EDGES)
 p53_dmg.metadata.update( {
     'name': 'p53_dmg',
     'description': 'The p53 GRN with damage present.',
-    'citation': '',
+    'citation': 'Choi, Minsoo, Jue Shi, Sung Hoon Jung, Xi Chen, and Kwang-Hyun Cho. Attractor Landscape Analysis Reveals Feedback Loops in the p53 Network That Control the Cellular Response to DNA Damage. Science Signaling 5, no. 251 (2012): ra83. doi:10.1126/scisignal.2003363.',
     } )
 
 # Get the path of the nodes and edges files for the mouse cortical gene regulatory network

--- a/neet/boolean/examples.py
+++ b/neet/boolean/examples.py
@@ -19,6 +19,11 @@ S_POMBE_EDGES = join(DATA_PATH, "s_pombe-edges.txt")
 The cell cycle network for *S. pombe* (fission yeast).
 """
 s_pombe = WTNetwork.read(S_POMBE_NODES, S_POMBE_EDGES)
+s_pombe.metadata.update( {
+    'name': 's_pombe',
+    'description': 'The cell cycle network for *S. pombe* (fission yeast).',
+    'citation': '',
+    } )
 
 # Get the path of the nodes and edges files for the budding yeast cell cycle
 S_CEREVISIAE_NODES = join(DATA_PATH, "s_cerevisiae-nodes.txt")
@@ -27,16 +32,25 @@ S_CEREVISIAE_EDGES = join(DATA_PATH, "s_cerevisiae-edges.txt")
 The cell cycle network for *S. cerevisiae* (budding yeast).
 """
 s_cerevisiae = WTNetwork.read(S_CEREVISIAE_NODES, S_CEREVISIAE_EDGES)
-
+s_cerevisiae.metadata.update( {
+    'name': 's_cerevisiae',
+    'description': 'The cell cycle network for *S. cerevisiae* (budding yeast).',
+    'citation': '',
+    } )
 
 # Get the path of the nodes and edges files for C. elegans
 C_ELEGANS_NODES = join(DATA_PATH, "c_elegans-nodes.dat")
 C_ELEGANS_EDGES = join(DATA_PATH, "c_elegans-edges.dat")
 
 """
-    The cell cycle network for *C. elegans*.
+The cell cycle network for *C. elegans*.
 """
 c_elegans = WTNetwork.read(C_ELEGANS_NODES, C_ELEGANS_EDGES)
+c_elegans.metadata.update( {
+    'name': 'c_elegans',
+    'description': 'The cell cycle network for *C. elegans*.',
+    'citation': '',
+    } )
 
 # Get the path of the nodes and edges files for the p53 GRN w/no damage
 P53_NO_DMG_NODES = join(DATA_PATH, "p53_no_dmg-nodes.txt")
@@ -44,8 +58,12 @@ P53_NO_DMG_EDGES = join(DATA_PATH, "p53_no_dmg-edges.txt")
 """
 The p53 GRN with no damage present.
 """
-
 p53_no_dmg = WTNetwork.read(P53_NO_DMG_NODES, P53_NO_DMG_EDGES)
+p53_no_dmg.metadata.update( {
+    'name': 'p53_no_dmg',
+    'description': 'The p53 GRN with no damage present.',
+    'citation': '',
+    } )
 
 # Get the path of the nodes and edges files for the p53 GRN w/damage
 P53_DMG_NODES = join(DATA_PATH, "p53_dmg-nodes.txt")
@@ -54,6 +72,11 @@ P53_DMG_EDGES = join(DATA_PATH, "p53_dmg-edges.txt")
 The p53 GRN with damage present.
 """
 p53_dmg = WTNetwork.read(P53_DMG_NODES, P53_DMG_EDGES)
+p53_dmg.metadata.update( {
+    'name': 'p53_dmg',
+    'description': 'The p53 GRN with damage present.',
+    'citation': '',
+    } )
 
 # Get the path of the nodes and edges files for the mouse cortical gene regulatory network
 # Edges are from either figure 7B or 7C (Giacomantonio, 2010)
@@ -75,24 +98,44 @@ The gene regulatory network for *mouse cortical* (anterior, initial, 7B edges).
 """
 mouse_cortical_ant_init_7B = WTNetwork.read(
     MOUSE_CORTICAL_ANT_INIT_NODES, MOUSE_CORTICAL_7B_EDGES)
+mouse_cortical_ant_init_7B.metadata.update( {
+    'name': 'mouse_cortical_ant_init_7B',
+    'description': 'The gene regulatory network for *mouse cortical* (anterior, initial, 7B edges).',
+    'citation': '',
+    } )
 
 """
 The gene regulatory network for *mouse cortical* (anterior, final, 7B edges).
 """
 mouse_cortical_ant_final_7B = WTNetwork.read(
     MOUSE_CORTICAL_ANT_FINAL_NODES, MOUSE_CORTICAL_7B_EDGES)
+mouse_cortical_ant_final_7B.metadata.update( {
+    'name': 'mouse_cortical_ant_final_7B',
+    'description': 'The gene regulatory network for *mouse cortical* (anterior, final, 7B edges).',
+    'citation': '',
+    } )
 
 """
 The gene regulatory network for *mouse cortical* (anterior, initial, 7C edges).
 """
 mouse_cortical_ant_init_7C = WTNetwork.read(
     MOUSE_CORTICAL_ANT_INIT_NODES, MOUSE_CORTICAL_7C_EDGES)
+mouse_cortical_ant_init_7C.metadata.update( {
+    'name': 'mouse_cortical_ant_init_7C',
+    'description': 'The gene regulatory network for *mouse cortical* (anterior, initial, 7C edges).',
+    'citation': '',
+    } )
 
 """
 The gene regulatory network for *mouse cortical* (anterior, final, 7C edges).
 """
 mouse_cortical_ant_final_7C = WTNetwork.read(
     MOUSE_CORTICAL_ANT_FINAL_NODES, MOUSE_CORTICAL_7C_EDGES)
+mouse_cortical_ant_final_7C.metadata.update( {
+    'name': 'mouse_cortical_ant_final_7C',
+    'description': 'The gene regulatory network for *mouse cortical* (anterior, final, 7C edges).',
+    'citation': '',
+    } )
 
 # Posterior mouse coritical networks ---------------------------------------------------------------
 """
@@ -100,24 +143,44 @@ The gene regulatory network for *mouse cortical* (posterior, initial, 7B edges).
 """
 mouse_cortical_post_init_7B = WTNetwork.read(
     MOUSE_CORTICAL_POST_INIT_NODES, MOUSE_CORTICAL_7B_EDGES)
+mouse_cortical_post_init_7B.metadata.update( {
+    'name': 'mouse_cortical_post_init_7B',
+    'description': 'The gene regulatory network for *mouse cortical* (posterior, initial, 7B edges).',
+    'citation': '',
+    } )
 
 """
 The gene regulatory network for *mouse cortical* (posterior, final, 7B edges).
 """
 mouse_cortical_post_final_7B = WTNetwork.read(
     MOUSE_CORTICAL_POST_FINAL_NODES, MOUSE_CORTICAL_7B_EDGES)
+mouse_cortical_post_final_7B.metadata.update( {
+    'name': 'mouse_cortical_post_final_7B',
+    'description': 'The gene regulatory network for *mouse cortical* (posterior, final, 7B edges).',
+    'citation': '',
+    } )
 
 """
 The gene regulatory network for *mouse cortical* (posterior, initial, 7C edges).
 """
 mouse_cortical_post_init_7C = WTNetwork.read(
     MOUSE_CORTICAL_POST_INIT_NODES, MOUSE_CORTICAL_7C_EDGES)
+mouse_cortical_post_init_7C.metadata.update( {
+    'name': 'mouse_cortical_post_init_7C',
+    'description': 'The gene regulatory network for *mouse cortical* (posterior, initial, 7C edges).',
+    'citation': '',
+    } )
 
 """
 The gene regulatory network for *mouse cortical* (posterior, final, 7C edges).
 """
 mouse_cortical_post_final_7C = WTNetwork.read(
     MOUSE_CORTICAL_POST_FINAL_NODES, MOUSE_CORTICAL_7C_EDGES)
+mouse_cortical_post_final_7C.metadata.update( {
+    'name': 'mouse_cortical_post_final_7C',
+    'description': 'The gene regulatory network for *mouse cortical* (posterior, final, 7C edges).',
+    'citation': '',
+    } )
 
 """
 Differentiation control network for *myeloid* progenitors.
@@ -126,4 +189,10 @@ MYELOID_TRUTH_TABLE = join(DATA_PATH, "myeloid-truth_table.txt")
 MYELOID_LOGIC_EXPRESSIONS = join(DATA_PATH, "myeloid-logic_expressions.txt")
 
 myeloid = LogicNetwork.read_table(MYELOID_TRUTH_TABLE)
+myeloid.metadata.update( {
+    'name': 'myeloid',
+    'description': 'Differentiation control network for *myeloid* progenitors.',
+    'citation': '',
+    } )
 myeloid_from_expr = LogicNetwork.read_logic(MYELOID_LOGIC_EXPRESSIONS)
+

--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -104,6 +104,8 @@ class LogicNetwork(object):
             for condition in row[1]:
                 conditions.add(''.join([str(int(s)) for s in condition]))
             self.table.append((row[0], conditions))
+            
+        self.metadata = {}
 
     def state_space(self):
         return self._state_space

--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -102,6 +102,8 @@ class WTNetwork(object):
         elif names is not None and len(names) != self.size:
             raise(ValueError("either all or none of the nodes may have a name"))
 
+        self.metadata = {}
+
     @property
     def size(self):
         """

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -633,3 +633,8 @@ class TestWTNetwork(unittest.TestCase):
             [0, 0, 0, 0, 0, 0, 1, 0, 0],
             s_pombe.update([0,0,0,0,0,0,0,0,1], values={1: 0, 2:0, 3:0})
         )
+
+    def test_has_metadata(self):
+        net = bnet.WTNetwork([[1]])
+        self.assertTrue(hasattr(net,'metadata'))
+        self.assertEqual(type(net.metadata),dict)

--- a/test/test_boolean_examples.py
+++ b/test/test_boolean_examples.py
@@ -61,7 +61,7 @@ class TestBooleanExamples(unittest.TestCase):
         Test that all examples have name, description, and citation metadata.
         """
         for net in all_example_networks():
-            self.assertTrue(net.metadata.has_key('name'))
-            self.assertTrue(net.metadata.has_key('description'))
-            self.assertTrue(net.metadata.has_key('citation'))
+            self.assertTrue('name' in net.metadata)
+            self.assertTrue('description' in net.metadata)
+            self.assertTrue('citation' in net.metadata)
 

--- a/test/test_boolean_examples.py
+++ b/test/test_boolean_examples.py
@@ -4,7 +4,32 @@
 import unittest
 import neet.boolean.examples as ex
 
+def all_example_networks():
+        return [
+            ex.s_pombe,
+            ex.s_cerevisiae,
+            ex.c_elegans,
+            ex.p53_no_dmg,
+            ex.p53_dmg,
+            ex.mouse_cortical_ant_init_7B,
+            ex.mouse_cortical_ant_final_7B,
+            ex.mouse_cortical_ant_init_7C,
+            ex.mouse_cortical_ant_final_7C,
+            ex.mouse_cortical_post_init_7B,
+            ex.mouse_cortical_post_final_7B,
+            ex.mouse_cortical_post_init_7C,
+            ex.mouse_cortical_post_final_7C,
+            ex.myeloid,
+        ]
+
 class TestBooleanExamples(unittest.TestCase):
+    
+    def test_examples_loaded(self):
+        """
+        Test that all example networks successfully load.
+        """
+        all_example_networks()
+            
     def test_s_pombe(self):
         self.assertEqual(9, ex.s_pombe.size)
         self.assertEqual(["SK", "Cdc2_Cdc13","Ste9","Rum1","Slp1","Cdc2_Cdc13_active","Wee1_Mik1","Cdc25","PP"],
@@ -30,3 +55,13 @@ class TestBooleanExamples(unittest.TestCase):
             self.assertEqual(10, mouse_network.size)
             self.assertEqual(["gF","gE","gP","gC","gS","pF","pE","pP","pC","pS"],
                 mouse_network.names)
+
+    def test_examples_metadata(self):
+        """
+        Test that all examples have name, description, and citation metadata.
+        """
+        for net in all_example_networks():
+            self.assertTrue(net.metadata.has_key('name'))
+            self.assertTrue(net.metadata.has_key('description'))
+            self.assertTrue(net.metadata.has_key('citation'))
+

--- a/test/test_logic.py
+++ b/test/test_logic.py
@@ -76,3 +76,9 @@ class TestLogicNetwork(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             net.update([0, 0, 1], pin=[0], values={0: 1})
+
+    def test_has_metadata(self):
+        net = LogicNetwork([((0,), {'0'})])
+        self.assertTrue(hasattr(net,'metadata'))
+        self.assertEqual(type(net.metadata),dict)
+


### PR DESCRIPTION
Adds a metadata dictionary to all boolean networks.

I added some example metadata to the networks in neet.boolean.examples.

Still to do: 
(1) We should add citation metadata for all the example networks.  (I think I got the right one for the p53 network, but someone should check.) 
(2) When constructing random networks in randomnet.py, we can add metadata that keeps track of what randomization was used.  This could/should include the random seed used (though we don't have a way of setting this yet.)

This contributes to issue #66 