### PR TITLE
The Landscape Class

### DIFF
--- a/docs/source/synchronous.rst
+++ b/docs/source/synchronous.rst
@@ -30,3 +30,47 @@ Synchronous Landscape Analysis Functions
     .. autofunction:: neet.synchronous.attractors
 
     .. autofunction:: neet.synchronous.basins
+
+Attractor Landscape
+^^^^^^^^^^^^^^^^^^^
+
+    .. autoclass:: neet.synchronous.Landscape
+
+        .. automethod:: neet.synchronous.Landscape.__init__
+
+Attributes
+""""""""""
+
+        .. autoattribute:: neet.synchronous.Landscape.network
+
+        .. autoattribute:: neet.synchronous.Landscape.size
+
+        .. autoattribute:: neet.synchronous.Landscape.transitions
+
+        .. autoattribute:: neet.synchronous.Landscape.attractors
+
+        .. autoattribute:: neet.synchronous.Landscape.attractor_lengths
+
+        .. autoattribute:: neet.synchronous.Landscape.basins
+
+        .. autoattribute:: neet.synchronous.Landscape.basin_sizes
+
+        .. autoattribute:: neet.synchronous.Landscape.in_degrees
+
+        .. autoattribute:: neet.synchronous.Landscape.heights
+
+        .. autoattribute:: neet.synchronous.Landscape.recurrence_times
+
+Methods
+"""""""
+        .. automethod:: neet.synchronous.Landscape.trajectory
+
+        .. automethod:: neet.synchronous.Landscape.timeseries
+
+        .. automethod:: neet.synchronous.Landscape.basin_entropy
+
+References
+^^^^^^^^^^
+
+.. [Krawitz2007] Krawitz, P. and Shmulevich, I. "Basin Entropy in Boolean Network Ensembles" *Phys. Rev. Lett.* **98**, 158701 (2007) `doi:10.1103/PhysRevLett.98.158701`__.
+.. __: https://dx.doi.org/10.1103/PhysRevLett.98.158701

--- a/docs/source/synchronous.rst
+++ b/docs/source/synchronous.rst
@@ -31,6 +31,8 @@ Synchronous Landscape Analysis Functions
 
     .. autofunction:: neet.synchronous.basins
 
+    .. autofunction:: neet.synchronous.basin_entropy
+
 Attractor Landscape
 ^^^^^^^^^^^^^^^^^^^
 

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -479,6 +479,12 @@ class Landscape(StateSpace):
             self.__expound()
         return self.__basins
 
+    @property
+    def basin_sizes(self):
+        if not self.__expounded:
+            self.__expound()
+        return self.__basin_sizes
+
     def __setup(self):
         """
         Compute all of the relavent computable values for the network:
@@ -502,6 +508,8 @@ class Landscape(StateSpace):
         basins = np.full(self.volume, -1, dtype=np.int)
         # Create a counter to keep track of how many basins have been visited
         basin_number = 0
+        # Create a list of basin sizes
+        basin_sizes = []
         # Create a list of attractor cycles
         attractors = []
 
@@ -538,6 +546,8 @@ class Landscape(StateSpace):
                 basin = basin_number
                 # Increment the basin number
                 basin_number += 1
+                # Add a new basin size
+                basin_sizes.append(0)
                 # Add the current state to the attractor cycle
                 cycle.append(state)
                 # We're still in the cycle until the current state is equal to the terminus
@@ -548,6 +558,8 @@ class Landscape(StateSpace):
 
             # Set the basin of the current state
             basins[state] = basin
+            # Increment the basin size
+            basin_sizes[basin] += 1
 
             # While we still have states on the stack
             while len(state_stack) != 0:
@@ -555,6 +567,8 @@ class Landscape(StateSpace):
                 state = state_stack.pop()
                 # Set the basin of the current state
                 basins[state] = basin
+                # Increment the basin_size
+                basin_sizes[basin] += 1
                 # If we're still in the cycle
                 if in_cycle:
                     # Add the current state to the attractor cycle
@@ -571,6 +585,7 @@ class Landscape(StateSpace):
                 attractors.append(np.asarray(cycle, dtype=np.int))
 
         self.__basins = basins
+        self.__basin_sizes = np.asarray(basin_sizes)
         self.__attractors = np.asarray(attractors)
         self.__expounded = True
 

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -606,3 +606,25 @@ class Landscape(StateSpace):
             path = [ decode(state) for state in path ]
 
         return path
+
+    def timeseries(self, timesteps):
+        if timesteps < 1:
+            raise ValueError("number of steps must be positive, non-zero")
+
+        trans = self.__transitions
+        decode = self.decode
+        encode = self._unsafe_encode
+        decoded_trans = [ decode(state) for state in trans ]
+        encoded_trans = [ encode(state) for state in decoded_trans ]
+
+        shape = (self.ndim, self.volume, timesteps + 1)
+        series = np.empty(shape, dtype=np.int)
+
+        for index, init in enumerate(self):
+            k = index
+            series[:, index, 0] = init[:]
+            for time in range(1, timesteps + 1):
+                series[:, index, time] = decoded_trans[k][:]
+                k = trans[k]
+
+        return series

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -499,6 +499,12 @@ class Landscape(StateSpace):
         return self.__heights
 
     @property
+    def attractor_lengths(self):
+        if not self.__expounded:
+            self.__expound()
+        return self.__attractor_lengths
+
+    @property
     def graph(self):
         if self.__graph is None:
             self.__graph = nx.DiGraph(list(enumerate(self.__transitions)))
@@ -535,6 +541,8 @@ class Landscape(StateSpace):
         basin_sizes = []
         # Create a list of attractor cycles
         attractors = []
+        # Create a list of attractor lengths
+        attractor_lengths = []
 
         # Start at state 0
         initial_state = 0
@@ -575,6 +583,8 @@ class Landscape(StateSpace):
                 basin_number += 1
                 # Add a new basin size
                 basin_sizes.append(0)
+                # Add a new attractor length
+                attractor_lengths.append(1)
                 # Add the current state to the attractor cycle
                 cycle.append(state)
                 # We're still in the cycle until the current state is equal to the terminus
@@ -604,6 +614,8 @@ class Landscape(StateSpace):
                 if in_cycle:
                     # Add the current state to the attractor cycle
                     cycle.append(state)
+                    # Increment the current attractor length
+                    attractor_lengths[basin] += 1
                     # We're still in the cycle until the current state is equal to the terminus
                     in_cycle = (terminus != state)
                 else:
@@ -621,6 +633,7 @@ class Landscape(StateSpace):
         self.__basins = basins
         self.__basin_sizes = np.asarray(basin_sizes)
         self.__attractors = np.asarray(attractors)
+        self.__attractor_lengths = np.asarray(attractor_lengths)
         self.__in_degrees = in_degrees
         self.__heights = heights
         self.__expounded = True

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -395,9 +395,14 @@ class Landscape(StateSpace):
         """
         Construct the landscape for a network.
 
+        .. rubric:: Example:
+
         ::
 
-            >>> Landscape(s_pombe)
+            >>> from neet.automata import ECA
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
             <neet.synchronous.Landscape object at 0x101c74810>
             >>> Landscape(ECA(30), size=5)
             <neet.synchronous.Landscape object at 0x10415b6d0>
@@ -435,38 +440,82 @@ class Landscape(StateSpace):
     @property
     def network(self):
         """
-        Get the landscape's dynamical network.
+        The landscape's dynamical network
 
-        :return: the dynamical network
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.network
+            array([array([76]), array([4]), array([8]), array([12]),
+                   array([144, 110, 384]), array([68]), array([72]), array([132]),
+                   array([136]), array([140]), array([196]), array([200]), array([204])], dtype=object)
         """
         return self.__net
 
     @property
     def size(self):
         """
-        Get the size of the dynamical network, i.e.. number of nodes.
+        The number of nodes in the landscape's dynamical network
 
-        :return: the size of the dynamical network
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.size
+            9
         """
         return self.ndim
 
     @property
     def transitions(self):
         """
-        Get the transitions array of the landscape. That is, return the
-        array of state whose indices are initial states and values are
-        the subsequent state.
+        The state transitions array
 
-        :return: the state transitions array
+        The transitions array is an array, indexed by states, whose
+        values are the subsequent state of the indexing state.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.transitions
+            array([  2,   2, 130, 130,   4,   0, 128, 128,   8,   0, 128, 128,  12,
+                     0, 128, 128, 256, 256, 384, 384, 260, 256, 384, 384, 264, 256,
+                   ...
+                   208, 208, 336, 336, 464, 464, 340, 336, 464, 464, 344, 336, 464,
+                   464, 348, 336, 464, 464])
         """
         return self.__transitions
 
     @property
     def attractors(self):
         """
-        Get the attractor cycles of the landscape.
+        The array of attractor cycles.
 
-        :return: an array of cycles, each an array
+        Each element of the array is an array of states in an attractor
+        cycle.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.attractors
+            array([array([76]), array([4]), array([8]), array([12]),
+                   array([144, 110, 384]), array([68]), array([72]), array([132]),
+                   array([136]), array([140]), array([196]), array([200]), array([204])], dtype=object)
         """
         if not self.__expounded:
             self.__expound()
@@ -475,6 +524,23 @@ class Landscape(StateSpace):
     @property
     def basins(self):
         """
+        The array of basin numbers, indexed by states.
+
+        This array associates each state with its basin number.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.basins
+            array([ 0,  0,  0,  0,  1,  0,  0,  0,  2,  0,  0,  0,  3,  0,  0,  0,  0,
+                    0,  4,  4,  0,  0,  4,  4,  0,  0,  4,  4,  0,  0,  4,  4,  4,  4,
+                    ...
+                    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+                    0,  0])
         """
         if not self.__expounded:
             self.__expound()
@@ -482,44 +548,145 @@ class Landscape(StateSpace):
 
     @property
     def basin_sizes(self):
+        """
+        The basin sizes as an array indexed by the basin number.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.basin_sizes
+            array([378,   2,   2,   2, 104,   6,   6,   2,   2,   2,   2,   2,   2])
+        """
         if not self.__expounded:
             self.__expound()
         return self.__basin_sizes
 
     @property
     def in_degrees(self):
+        """
+        The in-degree of each state as an array.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.in_degrees
+            array([ 6,  0,  4,  0,  2,  0,  0,  0,  2,  0,  0,  0,  2,  0,  0,  0, 12,
+                    0,  4,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+                    ...
+                    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+                    0,  0])
+
+        """
         if not self.__expounded:
             self.__expound()
         return self.__in_degrees
 
     @property
     def heights(self):
+        """
+        The height of each state as an array.
+
+        The *height* of a state is the number of time steps from that
+        state to a state in it's attractor cycle.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.heights
+            array([7, 7, 6, 6, 0, 8, 6, 6, 0, 8, 6, 6, 0, 8, 6, 6, 8, 8, 1, 1, 2, 8, 1,
+                   1, 2, 8, 1, 1, 2, 8, 1, 1, 2, 2, 2, 2, 9, 9, 1, 1, 9, 9, 1, 1, 9, 9,
+                   ...
+                   2, 3, 9, 9, 9, 3, 9, 9, 9, 3, 9, 9, 9, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                   3, 3, 3, 3, 3, 3])
+        """
         if not self.__expounded:
             self.__expound()
         return self.__heights
 
     @property
     def attractor_lengths(self):
+        """
+        The length of each attractor cycle as an array, indexed by the
+        attractor.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.attractor_lengths
+            array([1, 1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1])
+        """
         if not self.__expounded:
             self.__expound()
         return self.__attractor_lengths
 
     @property
     def recurrence_times(self):
+        """
+        The recurrence time of each state as an array.
+
+        The *recurrence time* is the number of time steps from that
+        state until a state is repeated.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.recurrence_times
+            array([7, 7, 6, 6, 0, 8, 6, 6, 0, 8, 6, 6, 0, 8, 6, 6, 8, 8, 3, 3, 2, 8, 3,
+                   3, 2, 8, 3, 3, 2, 8, 3, 3, 4, 4, 4, 4, 9, 9, 3, 3, 9, 9, 3, 3, 9, 9,
+                   ...
+                   4, 3, 9, 9, 9, 3, 9, 9, 9, 3, 9, 9, 9, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                   3, 3, 3, 3, 3, 3])
+        """
         if not self.__expounded:
             self.__expound()
         return self.__recurrence_times
 
     @property
     def graph(self):
+        """
+        The state transitions graph of the landscape as a
+        ``networkx.Digraph``.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.graph
+            <networkx.classes.digraph.DiGraph object at 0x106504810>
+        """
         if self.__graph is None:
             self.__graph = nx.DiGraph(list(enumerate(self.__transitions)))
         return self.__graph
 
     def __setup(self):
         """
-        Compute all of the relavent computable values for the network:
-            * transitions
+        This function performs all of the initilization-time setup of
+        the ``Landscape`` object. At present this is limited to
+        computing the state transitions array, but subsequent versions
+        may expand the work that ``__setup`` does.
         """
         update = self.__net._unsafe_update
         encode = self._unsafe_encode
@@ -531,6 +698,25 @@ class Landscape(StateSpace):
         self.__transitions = transitions
 
     def __expound(self):
+        """
+        This function performs the bulk of the calculations that the
+        ``Landscape`` is concerned with. Most of the properties in this
+        class are computed by this function whenever *any one* of them
+        is requested and the results are cached. The advantage of this
+        is that it saves computation time; why traverse the state space
+        for every property call when you can do it all at once. The
+        downside is that the cached results may use a good bit more
+        memory. This is a trade-off that we are willing to make for now.
+
+        The properties that are computed by this function include:
+            - :py:method:`.attractors`
+            - :py:method:`.basins`
+            - :py:method:`.basin_sizes`
+            - :py:method:`.in_degrees`
+            - :py:method:`.heights`
+            - :py:method:`.attractor_lengths`
+            - :py:method:`.recurrence_times`
+        """
         # Get the state transitions
         trans = self.__transitions
         # Create an array to store whether a given state has visited
@@ -658,6 +844,76 @@ class Landscape(StateSpace):
         self.__expounded = True
 
     def trajectory(self, init, timesteps=None, encode=None):
+        """
+        Compute the trajectory of a state.
+
+        This method computes a trajectory from ``init`` to the last
+        before the trajectory begins to repeat. If ``timesteps`` is
+        provided, then the trajectory will have a length of ``timesteps
+        + 1`` regardless of repeated states. The ``encode`` argument
+        forces the states in the trajectory to be either encoded or not.
+        When ``encode is None``, whether or not the states of the
+        trajectory are encoded is determined by whether or not the
+        initial state (``init``) is provided in encoded form.
+
+        Note that when ``timesteps is None``, the length of the
+        resulting trajectory should be one greater than the recurrence
+        time of the state.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.trajectory([1,0,0,1,0,1,1,0,1])
+            [[1, 0, 0, 1, 0, 1, 1, 0, 1],
+             [0, 0, 0, 0, 1, 0, 1, 0, 0],
+             [0, 0, 0, 0, 0, 0, 1, 0, 1],
+             [0, 1, 1, 1, 0, 0, 1, 0, 0],
+             [0, 0, 0, 0, 0, 0, 0, 1, 0],
+             [0, 1, 0, 0, 0, 1, 0, 1, 0],
+             [0, 1, 0, 0, 1, 1, 0, 1, 0],
+             [0, 0, 0, 0, 1, 0, 0, 1, 1],
+             [0, 0, 1, 1, 0, 0, 1, 0, 1],
+             [0, 0, 1, 1, 0, 0, 1, 0, 0]]
+
+            >>> landscape.trajectory([1,0,0,1,0,1,1,0,1], encode=True)
+            [361, 80, 320, 78, 128, 162, 178, 400, 332, 76]
+
+            >>> landscape.trajectory(361)
+            [361, 80, 320, 78, 128, 162, 178, 400, 332, 76]
+
+            >>> landscape.trajectory(361, encode=False)
+            [[1, 0, 0, 1, 0, 1, 1, 0, 1],
+             [0, 0, 0, 0, 1, 0, 1, 0, 0],
+             [0, 0, 0, 0, 0, 0, 1, 0, 1],
+             [0, 1, 1, 1, 0, 0, 1, 0, 0],
+             [0, 0, 0, 0, 0, 0, 0, 1, 0],
+             [0, 1, 0, 0, 0, 1, 0, 1, 0],
+             [0, 1, 0, 0, 1, 1, 0, 1, 0],
+             [0, 0, 0, 0, 1, 0, 0, 1, 1],
+             [0, 0, 1, 1, 0, 0, 1, 0, 1],
+             [0, 0, 1, 1, 0, 0, 1, 0, 0]]
+
+            >>> landscape.trajectory(361, timesteps=5)
+            [361, 80, 320, 78, 128, 162]
+
+            >>> landscape.trajectory(361, timesteps=10)
+            [361, 80, 320, 78, 128, 162, 178, 400, 332, 76, 76]
+
+        :param init: the initial state
+        :type init: ``int`` or an iterable
+        :param timesteps: the number of time steps to include in the trajectory
+        :type timesteps: ``int`` or ``None``
+        :param encode: whether to encode the states in the trajectory
+        :type encode: ``bool`` or ``None``
+        :return: a list whose elements are subsequent states of the trajectory
+
+        :raises ValueError: if ``init`` an empty array
+        :raises ValueError: if ``timesteps`` is less than :math:`1`
+        """
         decoded = isinstance(init, list) or isinstance(init, np.ndarray)
 
         if decoded:
@@ -691,6 +947,62 @@ class Landscape(StateSpace):
         return path
 
     def timeseries(self, timesteps):
+        """
+        Compute the full time series of the landscape.
+
+        This method computes a 3-dimensional array elements are the
+        states of each node in the network. The dimensions of the array
+        are indexed by, in order, the node, the initial state and the
+        time step.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.timeseries(5)
+            array([[[0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    ...,
+                    [1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0]],
+
+                   [[0, 1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 1, 0],
+                    [1, 1, 1, 1, 0, 0],
+                    ...,
+                    [0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0]],
+
+                   ...
+
+                   [[0, 0, 1, 1, 1, 1],
+                    [0, 0, 1, 1, 1, 1],
+                    [0, 1, 1, 1, 1, 0],
+                    ...,
+                    [1, 0, 0, 0, 0, 0],
+                    [1, 1, 0, 0, 0, 0],
+                    [1, 1, 0, 0, 0, 0]],
+
+                   [[0, 0, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 1, 1],
+                    ...,
+                    [1, 1, 1, 0, 0, 0],
+                    [1, 1, 1, 0, 0, 0],
+                    [1, 1, 1, 0, 0, 0]]])
+
+        :param timesteps: the number of timesteps to evolve the system
+        :type timesteps: ``int``
+        :return: a 3-D array of node states
+
+        :raises ValueError: if ``timesteps`` is less than :math:`1`
+        """
         if timesteps < 1:
             raise ValueError("number of steps must be positive, non-zero")
 
@@ -713,6 +1025,37 @@ class Landscape(StateSpace):
         return series
 
     def basin_entropy(self, base=None):
+        """
+        Compute the basin entropy of the landscape [Krawitz2007]_.
+
+        This method computes the Shannon entropy of the distribution of
+        basin sizes. The base of the logarithm is chosen to be the
+        number of basins so that the result is :math:`0 \leq h \leq 1`.
+        If there is fewer than :math:`2` basins, then the base is taken
+        to be :math:`2` so that the result is never `NaN`. The base can
+        be forcibly overridden with the ``base`` keyword argument.
+
+        .. rubric:: Example:
+
+        ::
+
+            >>> from math import e
+            >>> from neet.boolean.examples import s_pombe
+            >>> from neet.synchronous import Landscape
+            >>> landscape = Landscape(s_pombe)
+            >>> landscape.basin_entropy()
+            0.33020098338442544
+            >>> landscape.basin_entropy(base=2)
+            1.2218888338849747
+            >>> landscape.basin_entropy(base=10)
+            0.367825190366261
+            >>> landscape.basin_entropy(base=e)
+            0.8469488001650496
+
+        :param base: the base of the logarithm
+        :type base: a number or ``None``
+        :return: the basin entropy of the landscape of type ``float``
+        """
         if not self.__expounded:
             self.__expound()
         dist = pi.Dist(self.__basin_sizes)

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -293,11 +293,7 @@ def basins(net, size=None):
 
 def basin_entropy(net, size=None, base=2):
     """
-    Calculate the basin entropy.
-
-    Reference:
-    P. Krawitz and I. Shmulevich, ``Basin Entropy in Boolean Network Ensembles.''
-    Phys. Rev. Lett. 98, 158701 (2007).  http://dx.doi.org/10.1103/PhysRevLett.98.158701
+    Calculate the basin entropy [Krawitz2007]_.
 
     .. rubric:: Example:
 

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -643,3 +643,16 @@ class Landscape(StateSpace):
                 k = trans[k]
 
         return series
+
+    def basin_entropy(self, base=None):
+        if not self.__expounded:
+            self.__expound()
+        dist = pi.Dist(self.__basin_sizes)
+
+        if base is None:
+            base = len(dist)
+
+        if len(dist) < 2:
+            return 0.0
+        else:
+            return pi.shannon.entropy(dist, b=base)

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -382,3 +382,35 @@ def timeseries(net, timesteps, size=None):
             k = encoded_trans[k]
 
     return series
+
+class Landscape(object):
+    """
+    The ``Landscape`` class represents the structure and topology of the
+    "landscape" of state transitions. That is, it is the state space
+    together with information about state transitions and the topology of
+    the state transition graph.
+    """
+    def __init__(self, net, size=None):
+        """
+        Construct the landscape for a network.
+        
+        ::
+        
+            >>> Landscape(s_pombe)
+            <neet.synchronous.Landscape object at 0x101c74810>
+            >>> Landscape(ECA(30), size=5)
+            <neet.synchronous.Landscape object at 0x10415b6d0>
+
+        :param net: the network
+        :param size: the size of the network (``None`` if fixed sized)
+        :raises TypeError: if ``net`` is not a network
+        :raises ValueError: if ``net`` is fixed sized and ``size`` is not ``None``
+        :raises ValueError: if ``net`` is not fixed sized and ``size`` is ``None``
+        """
+
+        if not is_network(net):
+            raise TypeError("net is not a network")
+        elif is_fixed_sized(net) and size is not None:
+            raise ValueError("size must be None for fixed sized networks")
+        elif not is_fixed_sized(net) and size is None:
+            raise ValueError("size must not be None for variable sized networks")

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -422,31 +422,6 @@ class Landscape(object):
 
         self.__setup()
 
-    def __setup(self):
-        """
-        Compute all of the relavent computable values for the network:
-            * transitions
-        """
-        net = self.__net
-
-        if is_fixed_sized(self.__net):
-            state_space = net.state_space()
-        else:
-            state_space = net.state_space(self.__size)
-
-        volume = state_space.volume
-        self.__volume = volume
-
-        update = net._unsafe_update
-        encode = state_space._unsafe_encode
-
-        transitions = np.empty(volume, dtype=np.int)
-        for (i, state) in enumerate(state_space):
-            update(state)
-            transitions[i] = encode(state)
-
-        self.__transitions = transitions
-
     @property
     def network(self):
         """
@@ -475,6 +450,19 @@ class Landscape(object):
          return self.__volume
 
     @property
+    def state_space(self):
+        """
+        Get the state space associated with the landscape
+
+        :return: the dynamical system's StateSpace
+        """
+        net = self.__net
+        if is_fixed_sized(net):
+            return net.state_space()
+        else:
+            return net.state_space(self.__size)
+
+    @property
     def transitions(self):
         """
         Get the transitions array of the landscape. That is, return the
@@ -484,3 +472,24 @@ class Landscape(object):
         :return: the state transitions array
         """
         return self.__transitions
+
+    def __setup(self):
+        """
+        Compute all of the relavent computable values for the network:
+            * transitions
+        """
+        net = self.network
+        state_space = self.state_space
+
+        volume = state_space.volume
+
+        update = net._unsafe_update
+        encode = state_space._unsafe_encode
+
+        transitions = np.empty(volume, dtype=np.int)
+        for (i, state) in enumerate(state_space):
+            update(state)
+            transitions[i] = encode(state)
+
+        self.__volume = volume
+        self.__transitions = transitions

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -573,3 +573,36 @@ class Landscape(StateSpace):
         self.__basins = basins
         self.__attractors = np.asarray(attractors)
         self.__expounded = True
+
+    def trajectory(self, init, timesteps=None, encode=None):
+        decoded = isinstance(init, list) or isinstance(init, np.ndarray)
+
+        if decoded:
+            if init == []:
+                raise ValueError("initial state cannot be empty")
+            elif encode is None:
+                encode = False
+            init = self.encode(init)
+        elif encode is None:
+            encode = True
+
+        trans = self.__transitions
+        if timesteps is not None:
+            if timesteps < 1:
+                raise ValueError("number of steps must be positive, non-zero")
+
+            path = [init] * (timesteps + 1)
+            for i in range(1, len(path)):
+                path[i] = trans[path[i-1]]
+        else:
+            path = [init]
+            state = trans[init]
+            while state not in path:
+                path.append(state)
+                state = trans[state]
+
+        if not encode:
+            decode = self.decode
+            path = [ decode(state) for state in path ]
+
+        return path

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -471,6 +471,14 @@ class Landscape(StateSpace):
             self.__expound()
         return self.__attractors
 
+    @property
+    def basins(self):
+        """
+        """
+        if not self.__expounded:
+            self.__expound()
+        return self.__basins
+
     def __setup(self):
         """
         Compute all of the relavent computable values for the network:
@@ -491,9 +499,9 @@ class Landscape(StateSpace):
         # Create an array to store whether a given state has visited
         visited = np.zeros(self.volume, dtype=np.bool)
         # Create an array to store which attractor basin each state is in
-        basins = np.zeros(self.volume, dtype=np.int)
+        basins = np.full(self.volume, -1, dtype=np.int)
         # Create a counter to keep track of how many basins have been visited
-        basin_number = 1
+        basin_number = 0
         # Create a list of attractor cycles
         attractors = []
 
@@ -525,9 +533,11 @@ class Landscape(StateSpace):
                 visited[state] = True
 
             # If the next state hasn't been assigned a basin yet
-            if basins[next_state] == 0:
+            if basins[next_state] == -1:
                 # Set the current basin to the basin number
                 basin = basin_number
+                # Increment the basin number
+                basin_number += 1
                 # Add the current state to the attractor cycle
                 cycle.append(state)
                 # We're still in the cycle until the current state is equal to the terminus

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -487,6 +487,12 @@ class Landscape(StateSpace):
         return self.__basin_sizes
 
     @property
+    def in_degrees(self):
+        if not self.__expounded:
+            self.__expound()
+        return self.__in_degrees
+
+    @property
     def graph(self):
         if self.__graph is None:
             self.__graph = nx.DiGraph(list(enumerate(self.__transitions)))
@@ -513,6 +519,8 @@ class Landscape(StateSpace):
         visited = np.zeros(self.volume, dtype=np.bool)
         # Create an array to store which attractor basin each state is in
         basins = np.full(self.volume, -1, dtype=np.int)
+        # Create an array to store the in-degree of each state
+        in_degrees = np.zeros(self.volume, dtype=np.int)
         # Create a counter to keep track of how many basins have been visited
         basin_number = 0
         # Create a list of basin sizes
@@ -536,6 +544,8 @@ class Landscape(StateSpace):
             terminus = next_state = trans[state]
             # Set the visited flag of the current state
             visited[state] = True
+            # Increment in-degree
+            in_degrees[next_state] += 1
             # While the next state hasn't been visited
             while not visited[next_state]:
                 # Push the current state onto the stack
@@ -546,6 +556,8 @@ class Landscape(StateSpace):
                 terminus = next_state = trans[state]
                 # Update the visited flag for the current state
                 visited[state] = True
+                # Increment in-degree
+                in_degrees[next_state] += 1
 
             # If the next state hasn't been assigned a basin yet
             if basins[next_state] == -1:
@@ -594,6 +606,7 @@ class Landscape(StateSpace):
         self.__basins = basins
         self.__basin_sizes = np.asarray(basin_sizes)
         self.__attractors = np.asarray(attractors)
+        self.__in_degrees = in_degrees
         self.__expounded = True
 
     def trajectory(self, init, timesteps=None, encode=None):

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -1024,7 +1024,7 @@ class Landscape(StateSpace):
 
         return series
 
-    def basin_entropy(self, base=None):
+    def basin_entropy(self, base=2.0):
         """
         Compute the basin entropy of the landscape [Krawitz2007]_.
 
@@ -1044,7 +1044,7 @@ class Landscape(StateSpace):
             >>> from neet.synchronous import Landscape
             >>> landscape = Landscape(s_pombe)
             >>> landscape.basin_entropy()
-            0.33020098338442544
+            1.2218888338849747
             >>> landscape.basin_entropy(base=2)
             1.2218888338849747
             >>> landscape.basin_entropy(base=10)
@@ -1059,11 +1059,4 @@ class Landscape(StateSpace):
         if not self.__expounded:
             self.__expound()
         dist = pi.Dist(self.__basin_sizes)
-
-        if base is None:
-            base = len(dist)
-
-        if len(dist) < 2:
-            return 0.0
-        else:
-            return pi.shannon.entropy(dist, b=base)
+        return pi.shannon.entropy(dist, b=base)

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -428,6 +428,7 @@ class Landscape(StateSpace):
         self.__net = net
 
         self.__expounded = False
+        self.__graph = None
 
         self.__setup()
 
@@ -484,6 +485,12 @@ class Landscape(StateSpace):
         if not self.__expounded:
             self.__expound()
         return self.__basin_sizes
+
+    @property
+    def graph(self):
+        if self.__graph is None:
+            self.__graph = nx.DiGraph(list(enumerate(self.__transitions)))
+        return self.__graph
 
     def __setup(self):
         """

--- a/test/test_statespace.py
+++ b/test/test_statespace.py
@@ -85,7 +85,7 @@ class TestStateSpace(unittest.TestCase):
     def test_nonuniform_bases(self):
         spec = StateSpace([1, 2, 3, 2, 1])
         self.assertFalse(spec.is_uniform)
-        self.assertEqual([1, 2, 3, 2, 1], spec.bases)
+        self.assertEqual([1, 2, 3, 2, 1], spec.base)
         self.assertEqual(5, spec.ndim)
         self.assertEqual(12, spec.volume)
 

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -580,3 +580,58 @@ class TestLandscape(unittest.TestCase):
         """
         with self.assertRaises(ValueError):
             Landscape(MockFixedSizedNetwork(), size=3)
+
+    def test_transitions_eca(self):
+        ca = ECA(30)
+
+        l = Landscape(ca, size=1)
+        self.assertEqual(ca, l.network)
+        self.assertEqual(1, l.size)
+        self.assertEqual([0, 0], list(l.transitions))
+
+        l = Landscape(ca, size=2)
+        self.assertEqual(ca, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([0, 1, 2, 0], list(l.transitions))
+
+        l = Landscape(ca, size=3)
+        self.assertEqual(ca, l.network)
+        self.assertEqual(3, l.size)
+        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(l.transitions))
+
+        l = Landscape(ca, size=10)
+        trans = l.transitions
+        self.assertEqual(ca, l.network)
+        self.assertEqual(10, l.size)
+        self.assertEqual(1024, len(trans))
+        self.assertEqual([0, 515, 7, 517, 14, 525, 11, 521, 28, 543], list(trans[:10]))
+        self.assertEqual([18, 16, 13, 14, 10, 8, 7, 4, 2, 0], list(trans[-10:]))
+
+    def test_transitions_wtnetwork(self):
+        net = WTNetwork(
+            weights=[[1, 0], [-1, 1]],
+            thresholds=[0.5, 0.0],
+            theta=WTNetwork.positive_threshold
+        )
+
+        l = Landscape(net)
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size);
+        self.assertEqual([2,1,2,3], list(l.transitions))
+
+    def test_transitions_logicnetwork(self):
+        net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
+
+        l = Landscape(net)
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([1, 3, 1, 3], list(l.transitions))
+
+    def test_transitions_spombe(self):
+        l = Landscape(s_pombe)
+        self.assertEqual(s_pombe, l.network)
+        self.assertEqual(9, l.size)
+        trans = l.transitions
+        self.assertEqual(512, len(trans))
+        self.assertEqual([2, 2, 130, 130, 4, 0, 128, 128, 8, 0], list(trans[:10]))
+        self.assertEqual([464, 464, 344, 336, 464, 464, 348, 336, 464, 464], list(trans[-10:]))

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -862,3 +862,34 @@ class TestLandscape(unittest.TestCase):
 
         got = landscape.trajectory(state, timesteps=3, encode=False)
         self.assertEqual([[0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]], got)
+
+    def test_timeseries_too_short(self):
+        landscape = Landscape(ECA(30), size=3)
+        with self.assertRaises(ValueError):
+            landscape.timeseries(-1)
+
+        with self.assertRaises(ValueError):
+            landscape.timeseries(0)
+
+    def test_timeseries_eca(self):
+        rule = ECA(30)
+        for size in [5, 7, 11]:
+            landscape = Landscape(rule, size=size)
+            time = 10
+            series = landscape.timeseries(time)
+            self.assertEqual((size, 2**size, time + 1), series.shape)
+            for index, state in enumerate(rule.state_space(size)):
+                for t, expect in enumerate(landscape.trajectory(state, timesteps=time)):
+                    got = series[:, index, t]
+                    self.assertTrue(np.array_equal(expect, got))
+
+    def test_timeseries_wtnetworks(self):
+        for (net, size) in [(s_pombe, 9), (s_cerevisiae, 11), (c_elegans, 8)]:
+            landscape = Landscape(net)
+            time = 10
+            series = landscape.timeseries(time)
+            self.assertEqual((size, 2**size, time + 1), series.shape)
+            for index, state in enumerate(net.state_space()):
+                for t, expect in enumerate(landscape.trajectory(state, timesteps=time)):
+                    got = series[:, index, t]
+                    self.assertTrue(np.array_equal(expect, got))

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -8,8 +8,7 @@ from neet.boolean import WTNetwork, LogicNetwork
 from neet.boolean.examples import s_pombe, s_cerevisiae, c_elegans
 from neet.synchronous import *
 import numpy as np
-from .mock import MockObject, MockFixedSizedNetwork
-
+from .mock import MockObject, MockNetwork, MockFixedSizedNetwork
 
 class TestSynchronous(unittest.TestCase):
     """
@@ -540,3 +539,44 @@ class TestSynchronous(unittest.TestCase):
                 for t, expect in enumerate(trajectory(net, state, timesteps=time)):
                     got = series[:, index, t]
                     self.assertTrue(np.array_equal(expect, got))
+
+
+class TestLandscape(unittest.TestCase):
+    """
+    Test the ``neet.synchronous.Landscape`` class
+    """
+    def test_canary(self):
+        """
+        Canary test
+        """
+        self.assertTrue(True)
+
+    def test_init_not_network(self):
+        """
+        ``Landscape.__init__`` should raise a type error if ``net`` is not a
+        network.
+        """
+        with self.assertRaises(TypeError):
+            Landscape(MockObject())
+
+        with self.assertRaises(TypeError):
+            Landscape(MockObject(), size=5)
+
+    def test_init_not_fixed_sized(self):
+        """
+        ``Landscape.__init__`` should raise a value error if ``net`` is not
+        fixed sized and ``size`` is ``None``.
+        """
+        with self.assertRaises(ValueError):
+            Landscape(MockNetwork())
+
+        with self.assertRaises(ValueError):
+            Landscape(MockNetwork(), size=None)
+
+    def test_init_fixed_sized(self):
+        """
+        ``Landscape.__init__`` should raise a value errorif ``net`` is fixed
+        sized, but ``size`` is not ``None``.
+        """
+        with self.assertRaises(ValueError):
+            Landscape(MockFixedSizedNetwork(), size=3)

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -937,3 +937,17 @@ class TestLandscape(unittest.TestCase):
         for net, entropy in networks:
             landscape = Landscape(net)
             self.assertAlmostEqual(entropy, landscape.basin_entropy(base=10), places=6)
+
+    def test_graph_eca(self):
+        for size in range(2, 7):
+            landscape = Landscape(ECA(30), size=size)
+            g = landscape.graph
+            self.assertEqual(landscape.volume, g.number_of_nodes())
+            self.assertEqual(landscape.volume, g.number_of_edges())
+
+    def test_graph_wtnetworks(self):
+        for net in [s_pombe, s_cerevisiae, c_elegans]:
+            landscape = Landscape(net)
+            g = landscape.graph
+            self.assertEqual(landscape.volume, g.number_of_nodes())
+            self.assertEqual(landscape.volume, g.number_of_edges())

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -667,3 +667,29 @@ class TestLandscape(unittest.TestCase):
         for net, size in networks:
             landscape = Landscape(net)
             self.assertEqual(size, len(landscape.attractors))
+
+    def test_basins_eca(self):
+        networks = [(ECA(30), 2, 3), (ECA(30), 3, 1), (ECA(30), 4, 4),
+                    (ECA(30), 5, 2), (ECA(30), 6, 3), (ECA(110), 2, 1),
+                    (ECA(110), 3, 1), (ECA(110), 4, 3), (ECA(110), 5, 1),
+                    (ECA(110), 6, 3)]
+
+        for rule, width, size in networks:
+            landscape = Landscape(rule, size=width)
+            self.assertEqual(landscape.volume, len(landscape.basins))
+            self.assertEqual(size, 1 + np.max(landscape.basins))
+
+            unique = list(set(landscape.basins))
+            unique.sort()
+            self.assertEqual(list(range(size)), unique)
+
+    def test_attractors_wtnetworks(self):
+        networks = [(s_pombe, 13), (s_cerevisiae, 7), (c_elegans, 5)]
+        for net, size in networks:
+            landscape = Landscape(net)
+            self.assertEqual(landscape.volume, len(landscape.basins))
+            self.assertEqual(size, 1 + np.max(landscape.basins))
+
+            unique = list(set(landscape.basins))
+            unique.sort()
+            self.assertEqual(list(range(size)), unique)

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -951,3 +951,19 @@ class TestLandscape(unittest.TestCase):
             g = landscape.graph
             self.assertEqual(landscape.volume, g.number_of_nodes())
             self.assertEqual(landscape.volume, g.number_of_edges())
+
+    def test_in_degree(self):
+        for code in [30, 110, 21, 43]:
+            for size in range(2,7):
+                landscape = Landscape(ECA(code), size=size)
+                in_degrees = np.empty(landscape.volume, dtype=np.int)
+                for i in range(landscape.volume):
+                    in_degrees[i] = np.count_nonzero(landscape.transitions == i)
+                self.assertEqual(list(in_degrees), list(landscape.in_degrees))
+
+        for net in [s_pombe, s_cerevisiae, c_elegans]:
+            landscape = Landscape(net)
+            in_degrees = np.empty(landscape.volume, dtype=np.int)
+            for i in range(landscape.volume):
+                in_degrees[i] = np.count_nonzero(landscape.transitions == i)
+            self.assertEqual(list(in_degrees), list(landscape.in_degrees))

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -651,3 +651,19 @@ class TestLandscape(unittest.TestCase):
         self.assertEqual(list(space), list(l))
         self.assertEqual([ space.encode(state) for state in space ],
                          [ l.encode(state) for state in l])
+
+    def test_attractors_eca(self):
+        networks = [(ECA(30), 2, 3), (ECA(30), 3, 1), (ECA(30), 4, 4),
+                    (ECA(30), 5, 2), (ECA(30), 6, 3), (ECA(110), 2, 1),
+                    (ECA(110), 3, 1), (ECA(110), 4, 3), (ECA(110), 5, 1),
+                    (ECA(110), 6, 3)]
+
+        for rule, width, size in networks:
+            landscape = Landscape(rule, size=width)
+            self.assertEqual(size, len(landscape.attractors))
+
+    def test_attractors_wtnetworks(self):
+        networks = [(s_pombe, 13), (s_cerevisiae, 7), (c_elegans, 5)]
+        for net, size in networks:
+            landscape = Landscape(net)
+            self.assertEqual(size, len(landscape.attractors))

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -635,3 +635,19 @@ class TestLandscape(unittest.TestCase):
         self.assertEqual(512, len(trans))
         self.assertEqual([2, 2, 130, 130, 4, 0, 128, 128, 8, 0], list(trans[:10]))
         self.assertEqual([464, 464, 344, 336, 464, 464, 348, 336, 464, 464], list(trans[-10:]))
+
+    def test_is_state_space(self):
+        self.assertTrue(issubclass(Landscape, StateSpace))
+
+        space = s_pombe.state_space()
+        l = Landscape(s_pombe)
+        self.assertEqual(list(space), list(l))
+        self.assertEqual([ space.encode(state) for state in space ],
+                         [ l.encode(state) for state in l])
+
+        ca = ECA(30)
+        space = ca.state_space(10)
+        l = Landscape(ca, size=10)
+        self.assertEqual(list(space), list(l))
+        self.assertEqual([ space.encode(state) for state in space ],
+                         [ l.encode(state) for state in l])

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -1004,3 +1004,21 @@ class TestLandscape(unittest.TestCase):
             landscape = Landscape(net)
             lengths = list(map(len, landscape.attractors))
             self.assertEqual(lengths, list(landscape.attractor_lengths))
+
+    def test_recurrence_times(self):
+        for code in [30, 110, 21, 43]:
+            for size in range(2,7):
+                landscape = Landscape(ECA(code), size=size)
+                recurrence_times = [0] * landscape.volume
+                for i in range(landscape.volume):
+                    b = landscape.basins[i]
+                    recurrence_times[i] = landscape.heights[i] + landscape.attractor_lengths[b] - 1
+                self.assertEqual(recurrence_times, list(landscape.recurrence_times))
+
+        for net in [s_pombe, s_cerevisiae, c_elegans]:
+            landscape = Landscape(net)
+            recurrence_times = [0] * landscape.volume
+            for i in range(landscape.volume):
+                b = landscape.basins[i]
+                recurrence_times[i] = landscape.heights[i] + landscape.attractor_lengths[b] - 1
+            self.assertEqual(recurrence_times, list(landscape.recurrence_times))

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -693,3 +693,172 @@ class TestLandscape(unittest.TestCase):
             unique = list(set(landscape.basins))
             unique.sort()
             self.assertEqual(list(range(size)), unique)
+
+    def test_trajectory_too_short(self):
+        landscape = Landscape(ECA(30), size=3)
+        with self.assertRaises(ValueError):
+            landscape.trajectory([0, 0, 0], timesteps=-1)
+
+        with self.assertRaises(ValueError):
+            landscape.trajectory([0, 0, 0], timesteps=0)
+
+    def test_trajectory_eca(self):
+        landscape = Landscape(ECA(30), size=3)
+
+        with self.assertRaises(ValueError):
+            landscape.trajectory([])
+
+        with self.assertRaises(ValueError):
+            landscape.trajectory([0, 1])
+
+        xs = [0, 1, 0]
+
+        got = landscape.trajectory(xs)
+        self.assertEqual([0, 1, 0], xs)
+        self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0]], got)
+
+        got = landscape.trajectory(xs, timesteps=5)
+        self.assertEqual([0, 1, 0], xs)
+        self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0],
+                          [0, 0, 0], [0, 0, 0], [0, 0, 0]], got)
+
+        got = landscape.trajectory(xs, encode=False)
+        self.assertEqual([0, 1, 0], xs)
+        self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0]], got)
+
+        got = landscape.trajectory(xs, timesteps=5, encode=False)
+        self.assertEqual([0, 1, 0], xs)
+        self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0],
+                          [0, 0, 0], [0, 0, 0], [0, 0, 0]], got)
+
+        got = landscape.trajectory(xs, encode=True)
+        self.assertEqual([0, 1, 0], xs)
+        self.assertEqual([2, 7, 0], list(got))
+
+        got = landscape.trajectory(xs, timesteps=5, encode=True)
+        self.assertEqual([0, 1, 0], xs)
+        self.assertEqual([2, 7, 0, 0, 0, 0], list(got))
+
+        xs = 2
+        got = landscape.trajectory(xs)
+        self.assertEqual([2, 7, 0], list(got))
+
+        got = landscape.trajectory(xs, timesteps=5)
+        self.assertEqual([2, 7, 0, 0, 0, 0], list(got))
+
+        got = landscape.trajectory(xs, encode=True)
+        self.assertEqual([2, 7, 0], list(got))
+
+        got = landscape.trajectory(xs, timesteps=5, encode=True)
+        self.assertEqual([2, 7, 0, 0, 0, 0], list(got))
+
+        got = landscape.trajectory(xs, encode=False)
+        self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0]], got)
+
+        got = landscape.trajectory(xs, timesteps=5, encode=False)
+        self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0],
+                          [0, 0, 0], [0, 0, 0], [0, 0, 0]], got)
+
+    def test_trajectory_wtnetwork(self):
+        net = WTNetwork(
+            weights=[[1, 0], [-1, 0]],
+            thresholds=[0.5, 0.0],
+            theta=WTNetwork.positive_threshold
+        )
+
+        landscape = Landscape(net)
+
+        state = [0, 0]
+        got = landscape.trajectory(state)
+        self.assertEqual([0, 0], state)
+        self.assertEqual([[0, 0], [0, 1]], got)
+
+        got = landscape.trajectory(state, timesteps=3)
+        self.assertEqual([0, 0], state)
+        self.assertEqual([[0, 0], [0, 1], [0, 1], [0, 1]], got)
+
+        got = landscape.trajectory(state, encode=False)
+        self.assertEqual([0, 0], state)
+        self.assertEqual([[0, 0], [0, 1]], got)
+
+        got = landscape.trajectory(state, timesteps=3, encode=False)
+        self.assertEqual([0, 0], state)
+        self.assertEqual([[0, 0], [0, 1], [0, 1], [0, 1]], got)
+
+        got = landscape.trajectory(state, encode=True)
+        self.assertEqual([0, 0], state)
+        self.assertEqual([0, 2], got)
+
+        got = landscape.trajectory(state, timesteps=3, encode=True)
+        self.assertEqual([0, 0], state)
+        self.assertEqual([0, 2, 2, 2], got)
+
+        state = 0
+        got = landscape.trajectory(state)
+        self.assertEqual([0, 2], got)
+
+        got = landscape.trajectory(state, timesteps=3)
+        self.assertEqual([0, 2, 2, 2], got)
+
+        got = landscape.trajectory(state, encode=True)
+        self.assertEqual([0, 2], got)
+
+        got = landscape.trajectory(state, timesteps=3, encode=True)
+        self.assertEqual([0, 2, 2, 2], got)
+
+        got = landscape.trajectory(state, encode=False)
+        self.assertEqual([[0, 0], [0, 1]], got)
+
+        got = landscape.trajectory(state, timesteps=3, encode=False)
+        self.assertEqual([[0, 0], [0, 1], [0, 1], [0, 1]], got)
+
+    def test_trajectory_logicnetwork(self):
+        net = LogicNetwork([((1, 2), {'01', '10'}),
+                            ((0, 2), {'01', '10', '11'}),
+                            ((0, 1), {'11'})])
+
+        landscape = Landscape(net)
+
+        state = [0, 1, 0]
+        got = landscape.trajectory(state, encode=False)
+        self.assertEqual([0, 1, 0], state)
+        self.assertEqual([[0, 1, 0], [1, 0, 0]], got)
+
+        got = landscape.trajectory(state, timesteps=3, encode=False)
+        self.assertEqual([0, 1, 0], state)
+        self.assertEqual([[0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]], got)
+
+        got = landscape.trajectory(state)
+        self.assertEqual([0, 1, 0], state)
+        self.assertEqual([[0, 1, 0], [1, 0, 0]], got)
+
+        got = landscape.trajectory(state, timesteps=3)
+        self.assertEqual([0, 1, 0], state)
+        self.assertEqual([[0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]], got)
+
+        got = landscape.trajectory(state, encode=True)
+        self.assertEqual([0, 1, 0], state)
+        self.assertEqual([2, 1], got)
+
+        got = landscape.trajectory(state, timesteps=3, encode=True)
+        self.assertEqual([0, 1, 0], state)
+        self.assertEqual([2, 1, 2, 1], got)
+
+        state = 2
+        got = landscape.trajectory(state)
+        self.assertEqual([2, 1], got)
+
+        got = landscape.trajectory(state, timesteps=3)
+        self.assertEqual([2, 1, 2, 1], got)
+
+        got = landscape.trajectory(state, encode=True)
+        self.assertEqual([2, 1], got)
+
+        got = landscape.trajectory(state, timesteps=3, encode=True)
+        self.assertEqual([2, 1, 2, 1], got)
+
+        got = landscape.trajectory(state, encode=False)
+        self.assertEqual([[0, 1, 0], [1, 0, 0]], got)
+
+        got = landscape.trajectory(state, timesteps=3, encode=False)
+        self.assertEqual([[0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]], got)

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -904,39 +904,33 @@ class TestLandscape(unittest.TestCase):
             self.assertEqual(histogram, list(landscape.basin_sizes))
 
     def test_basin_entropy_eca(self):
-        networks = [(ECA(30),  2, 0.946395),
-                    (ECA(30),  3, 0.000000),
-                    (ECA(30),  4, 0.593139),
-                    (ECA(30),  5, 0.337290),
-                    (ECA(30),  6, 0.146295),
-                    (ECA(110), 2, 0.000000),
-                    (ECA(110), 3, 0.000000),
-                    (ECA(110), 4, 0.985057),
-                    (ECA(110), 5, 0.000000),
-                    (ECA(110), 6, 0.926844)]
+        networks = [(ECA(30),  2, 1.500000, 0.451545),
+                    (ECA(30),  3, 0.000000, 0.000000),
+                    (ECA(30),  4, 1.186278, 0.357105),
+                    (ECA(30),  5, 0.337290, 0.101534),
+                    (ECA(30),  6, 0.231872, 0.069801),
+                    (ECA(110), 2, 0.000000, 0.000000),
+                    (ECA(110), 3, 0.000000, 0.000000),
+                    (ECA(110), 4, 1.561278, 0.469992),
+                    (ECA(110), 5, 0.000000, 0.000000),
+                    (ECA(110), 6, 1.469012, 0.442217)]
 
-        for net, width, entropy in networks:
+        for net, width, base2, base10 in networks:
             landscape = Landscape(net, size=width)
-            self.assertAlmostEqual(entropy, landscape.basin_entropy(), places=6)
+            self.assertAlmostEqual(base2, landscape.basin_entropy(), places=6)
+            self.assertAlmostEqual(base2, landscape.basin_entropy(base=2), places=6)
+            self.assertAlmostEqual(base10, landscape.basin_entropy(base=10), places=6)
 
     def test_basin_entropy_wtnetwork(self):
-        networks = [(s_pombe,      0.330201),
-                    (s_cerevisiae, 0.279216),
-                    (c_elegans,    0.367913)]
+        networks = [(s_pombe,      1.221889, 0.367825),
+                    (s_cerevisiae, 0.783858, 0.235965),
+                    (c_elegans,    0.854267, 0.257160)]
 
-        for net, entropy in networks:
+        for net, base2, base10 in networks:
             landscape = Landscape(net)
-            self.assertAlmostEqual(entropy, landscape.basin_entropy(), places=6)
-
-    def test_basin_entropy_wtnetwork_base10(self):
-        networks = [(s_pombe,      0.367825),
-                    (s_cerevisiae, 0.235965),
-                    (c_elegans,    0.257160),
-                    ]
-
-        for net, entropy in networks:
-            landscape = Landscape(net)
-            self.assertAlmostEqual(entropy, landscape.basin_entropy(base=10), places=6)
+            self.assertAlmostEqual(base2, landscape.basin_entropy(), places=6)
+            self.assertAlmostEqual(base2, landscape.basin_entropy(base=2), places=6)
+            self.assertAlmostEqual(base10, landscape.basin_entropy(base=10), places=6)
 
     def test_graph_eca(self):
         for size in range(2, 7):

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -884,7 +884,7 @@ class TestLandscape(unittest.TestCase):
                     self.assertTrue(np.array_equal(expect, got))
 
     def test_timeseries_wtnetworks(self):
-        for (net, size) in [(s_pombe, 9), (s_cerevisiae, 11), (c_elegans, 8)]:
+        for net, size in [(s_pombe, 9), (s_cerevisiae, 11), (c_elegans, 8)]:
             landscape = Landscape(net)
             time = 10
             series = landscape.timeseries(time)
@@ -893,3 +893,12 @@ class TestLandscape(unittest.TestCase):
                 for t, expect in enumerate(landscape.trajectory(state, timesteps=time)):
                     got = series[:, index, t]
                     self.assertTrue(np.array_equal(expect, got))
+
+    def test_basin_sizes(self):
+        for net in [s_pombe, s_cerevisiae, c_elegans]:
+            landscape = Landscape(net)
+            basins = landscape.basins
+            histogram = [0] * (np.max(basins) + 1)
+            for b in basins:
+                histogram[b] += 1
+            self.assertEqual(histogram, list(landscape.basin_sizes))

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -902,3 +902,38 @@ class TestLandscape(unittest.TestCase):
             for b in basins:
                 histogram[b] += 1
             self.assertEqual(histogram, list(landscape.basin_sizes))
+
+    def test_basin_entropy_eca(self):
+        networks = [(ECA(30),  2, 0.946395),
+                    (ECA(30),  3, 0.000000),
+                    (ECA(30),  4, 0.593139),
+                    (ECA(30),  5, 0.337290),
+                    (ECA(30),  6, 0.146295),
+                    (ECA(110), 2, 0.000000),
+                    (ECA(110), 3, 0.000000),
+                    (ECA(110), 4, 0.985057),
+                    (ECA(110), 5, 0.000000),
+                    (ECA(110), 6, 0.926844)]
+
+        for net, width, entropy in networks:
+            landscape = Landscape(net, size=width)
+            self.assertAlmostEqual(entropy, landscape.basin_entropy(), places=6)
+
+    def test_basin_entropy_wtnetwork(self):
+        networks = [(s_pombe,      0.330201),
+                    (s_cerevisiae, 0.279216),
+                    (c_elegans,    0.367913)]
+
+        for net, entropy in networks:
+            landscape = Landscape(net)
+            self.assertAlmostEqual(entropy, landscape.basin_entropy(), places=6)
+
+    def test_basin_entropy_wtnetwork_base10(self):
+        networks = [(s_pombe,      0.367825),
+                    (s_cerevisiae, 0.235965),
+                    (c_elegans,    0.257160),
+                    ]
+
+        for net, entropy in networks:
+            landscape = Landscape(net)
+            self.assertAlmostEqual(entropy, landscape.basin_entropy(base=10), places=6)

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -992,3 +992,15 @@ class TestLandscape(unittest.TestCase):
                     heights[i] += 1
                     state = landscape.transitions[state]
             self.assertEqual(heights, list(landscape.heights))
+
+    def test_attractor_lengths(self):
+        for code in [30, 110, 21, 43]:
+            for size in range(2,7):
+                landscape = Landscape(ECA(code), size=size)
+                lengths = list(map(len, landscape.attractors))
+                self.assertEqual(lengths, list(landscape.attractor_lengths))
+
+        for net in [s_pombe, s_cerevisiae, c_elegans]:
+            landscape = Landscape(net)
+            lengths = list(map(len, landscape.attractors))
+            self.assertEqual(lengths, list(landscape.attractor_lengths))

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -967,3 +967,28 @@ class TestLandscape(unittest.TestCase):
             for i in range(landscape.volume):
                 in_degrees[i] = np.count_nonzero(landscape.transitions == i)
             self.assertEqual(list(in_degrees), list(landscape.in_degrees))
+
+    def test_heights(self):
+        for code in [30, 110, 21, 43]:
+            for size in range(2,7):
+                landscape = Landscape(ECA(code), size=size)
+                heights = [0] * landscape.volume
+                for i in range(landscape.volume):
+                    b = landscape.basins[i]
+                    state = i
+                    while state not in landscape.attractors[b]:
+                        heights[i] += 1
+                        state = landscape.transitions[state]
+                self.assertEqual(heights, list(landscape.heights))
+
+
+        for net in [s_pombe, s_cerevisiae, c_elegans]:
+            landscape = Landscape(net)
+            heights = [0] * landscape.volume
+            for i in range(landscape.volume):
+                b = landscape.basins[i]
+                state = i
+                while state not in landscape.attractors[b]:
+                    heights[i] += 1
+                    state = landscape.transitions[state]
+            self.assertEqual(heights, list(landscape.heights))


### PR DESCRIPTION
# Concept
The `Landscape` class provides an abstraction that allows for efficient caching of quantities computed over an attractor landscape. Many useful computations require traversal over the state transition graph of a network. The convenient thing is that we can compute most of these quantities simultaneously, only traversing the graph once.

# Design
In this implementation, the computation of quantities such as `attractors` and `in_degree` are all postponed until they are requested. When any one is desired, all of them are computed and cached. This means that subsequent requests, rather than having a computational complexity `O(N)`<sup>1.</sup>, have complexity `O(1)`.

# Features
A key feature of our implementation is that `Landscape` is a subclass of `StateSpace`. In other words, we think of a `Landscape` as a `StateSpace` with additional information about the dynamics of the system. This means that `Landscape` has all of the properties of a `StateSpace` including:
- it is iterable
- it has an inclusion test
- it has `encode` and `decode` methods

A few of the properties that are currently implemented include:
- `transitions` - the state transitions array
- `attractors` - the array of attractor cycles, each themselves an array
- `basins` - the array which is indexed by states in the network and whose values are the basin of attraction to which the state belongs
- `basin_sizes` - the array of basin sizes
- `attractor_lengths` - the array of attractor lengths, indexed by the basin number
- `heights` - the array of heights<sup>2.</sup> of the states
- `recurrence_times` - the array of recurrence times<sup>3.</sup>of the states
- `graph` - the state transition graph as a `networkx.DiGraph`
- `in_degrees` - the array of in-degrees of each state in the landscape

In addition to these properties, we also implemented three methods:
- `trajectory` - computes a trajectory from a given state
- `timeseries` - computes a time series of a given length from every initial state
- `basin_entropy` - computes the basin entropy the landscape

# Footnotes
1. Here `N` is the number of states in the landscape or nodes in the state transition graph.
2. Height here means the number of time steps from a state to the first state in an attractor.
3. The recurrence time of a state is the number of time steps that can be take from that state before any state is repeated.
