### PR TITLE
Add functions to treat logic 'connections' that bear no influence

### DIFF
--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -124,6 +124,8 @@ class LogicNetwork(object):
         :type index: int or None
         :param pin: the indices to pin (or None)
         :type pin: sequence
+        :param values: override values
+        :type values: dict
         :returns: the updated states
 
         .. rubric:: Basic Use:
@@ -205,6 +207,8 @@ class LogicNetwork(object):
         :type index: int or None
         :param pin: the indices to pin (or None)
         :type pin: sequence
+        :param values: override values
+        :type values: dict
         :returns: the updated states
 
         .. rubric:: Basic Use:
@@ -460,6 +464,31 @@ class LogicNetwork(object):
 
         return cls(table, names)
 
+    def is_dependent(self, target, source):
+        """
+        Return True if state of `target` is influenced by the state of `source`.
+
+        :param target: index of the target node
+        :param source: index of the source node
+        """
+        sub_table = self.table[target]
+        if source not in sub_table[0]: # No explicit dependency.
+            return False
+        
+        # Determine implicit dependency.
+        i = sub_table[0].index(source)
+        counter = {}
+        for state in sub_table[1]:
+            state_sans_source = state[:i] + state[i+1:] # State excluding source.
+            if int(state[i]) == 1:
+                counter[state_sans_source] = counter.get(state_sans_source, 0) + 1
+            else:
+                counter[state_sans_source] = counter.get(state_sans_source, 0) - 1
+
+        if any(counter.values()): # States uneven.
+            return True
+        return False
+
     # def _incoming_neighbors(self,index=None):
     #     if index:
     #         return list(self.table[index][0])
@@ -512,7 +541,6 @@ class LogicNetwork(object):
                 outgoing_neighbors.append(i)
         
         return set(outgoing_neighbors)
-
 
     def neighbors(self,index=None,direction='both'):
         """

--- a/test/test_logic.py
+++ b/test/test_logic.py
@@ -220,15 +220,40 @@ class TestLogicNetwork(unittest.TestCase):
         self.assertEqual(net.neighbors(index=2,direction='both'),set([0, 1, 2]))
 
     def test_node_dependency(self):
-        net = LogicNetwork([((1, 2), set(['11', '10'])), 
-                            ((0,), set(['1'])), 
-                            ((0, 1, 2), set(['010', '011', '101', '100'])), 
-                            ((3,), set(['1']))])
+        net = LogicNetwork([((1, 2), {'11', '10'}), 
+                            ((0,), {'1'}), 
+                            ((0, 1, 2), {'010', '011', '101', '100'})])
 
         self.assertTrue(net.is_dependent(0, 1))
         self.assertFalse(net.is_dependent(0, 2))
-        self.assertFalse(net.is_dependent(0, 3))
 
         self.assertFalse(net.is_dependent(2, 2))
         self.assertTrue(net.is_dependent(2, 0))
         self.assertTrue(net.is_dependent(2, 1))
+
+    def test_reduce_table(self):
+        net = LogicNetwork([((1, 2), {'11', '10'}),
+                            ((0,), {'1'}),
+                            ((0, 1, 2), {'010', '011', '101', '100'})],
+                           reduced=True)
+
+        self.assertEqual(net.table,
+                         [((1,), {'1'}),
+                          ((0,), {'1'}),
+                          ((0, 1), {'01', '10'})])
+
+        net = LogicNetwork([((0, 1), {'00', '01', '10', '11'}),
+                            ((1,), {'1'})],
+                           reduced=True)
+
+        self.assertEqual(net.table,
+                         [((0,), {'0', '1'}),
+                          ((1,), {'1'})])
+
+        net = LogicNetwork([((1,), {'0', '1'}),
+                            ((1,), {'1'})],
+                           reduced=True)
+
+        self.assertEqual(net.table,
+                         [((0,), {'1'}),
+                          ((1,), {'1'})])

--- a/test/test_logic.py
+++ b/test/test_logic.py
@@ -204,8 +204,7 @@ class TestLogicNetwork(unittest.TestCase):
                                                          set([0, 2]), 
                                                          set([0, 2]), 
                                                          set([3])])
-
-        
+       
     def test_neighbors_both(self):
         
         net = LogicNetwork([((1, 2), set(['11', '10'])), 
@@ -220,6 +219,16 @@ class TestLogicNetwork(unittest.TestCase):
 
         self.assertEqual(net.neighbors(index=2,direction='both'),set([0, 1, 2]))
 
+    def test_node_dependency(self):
+        net = LogicNetwork([((1, 2), set(['11', '10'])), 
+                            ((0,), set(['1'])), 
+                            ((0, 1, 2), set(['010', '011', '101', '100'])), 
+                            ((3,), set(['1']))])
 
+        self.assertTrue(net.is_dependent(0, 1))
+        self.assertFalse(net.is_dependent(0, 2))
+        self.assertFalse(net.is_dependent(0, 3))
 
-
+        self.assertFalse(net.is_dependent(2, 2))
+        self.assertTrue(net.is_dependent(2, 0))
+        self.assertTrue(net.is_dependent(2, 1))

--- a/test/test_logic.py
+++ b/test/test_logic.py
@@ -6,6 +6,7 @@ import unittest
 from neet.boolean import LogicNetwork
 from neet.exceptions import FormatError
 
+
 class TestLogicNetwork(unittest.TestCase):
     def test_is_network(self):
         from neet.interfaces import is_network
@@ -79,149 +80,157 @@ class TestLogicNetwork(unittest.TestCase):
 
     def test_has_metadata(self):
         net = LogicNetwork([((0,), {'0'})])
-        self.assertTrue(hasattr(net,'metadata'))
-        self.assertEqual(type(net.metadata),dict)
-
-    
+        self.assertTrue(hasattr(net, 'metadata'))
+        self.assertEqual(type(net.metadata), dict)
 
     def test_logic_simple_read(self):
         from os.path import dirname, abspath, realpath, join
 
-        ## Determine the path to the "data" directory of the neet.test module
+        # Determine the path to the "data" directory of the neet.test module
         DATA_PATH = join(dirname(abspath(realpath(__file__))), "data")
 
-        ## Test simple network read in
+        # Test simple network read in
         SIMPLE_TRUTH_TABLE = join(DATA_PATH, "test_simple-truth_table.txt")
         simple = LogicNetwork.read_table(SIMPLE_TRUTH_TABLE)
 
         self.assertEqual(simple.names, ['A', 'B', 'C', 'D'])
-        self.assertEqual(simple.table, [((1, 2), set(['11', '10'])), 
-                                        ((0,), set(['1'])), 
-                                        ((1, 2, 0), set(['010', '011', '101'])), 
+        self.assertEqual(simple.table, [((1, 2), set(['11', '10'])),
+                                        ((0,), set(['1'])),
+                                        ((1, 2, 0), set(
+                                            ['010', '011', '101'])),
                                         ((3,), set(['1']))])
         simple.neighbors()
 
     def test_logic_simple_read_no_commas(self):
         from os.path import dirname, abspath, realpath, join
 
-        ## Determine the path to the "data" directory of the neet.test module
+        # Determine the path to the "data" directory of the neet.test module
         DATA_PATH = join(dirname(abspath(realpath(__file__))), "data")
 
-        ## Test simple network read in (no commas)
-        SIMPLE_TRUTH_TABLE = join(DATA_PATH, "test_simple_no_commas-truth_table.txt")
+        # Test simple network read in (no commas)
+        SIMPLE_TRUTH_TABLE = join(
+            DATA_PATH, "test_simple_no_commas-truth_table.txt")
         simple = LogicNetwork.read_table(SIMPLE_TRUTH_TABLE)
 
         self.assertEqual(simple.names, ['A', 'B', 'C', 'D'])
-        self.assertEqual(simple.table, [((1, 2), set(['11', '10'])), 
-                                        ((0,), set(['1'])), 
-                                        ((1, 2, 0), set(['010', '011', '101'])), 
+        self.assertEqual(simple.table, [((1, 2), set(['11', '10'])),
+                                        ((0,), set(['1'])),
+                                        ((1, 2, 0), set(
+                                            ['010', '011', '101'])),
                                         ((3,), set(['1']))])
 
     def test_logic_simple_read_no_header(self):
         from os.path import dirname, abspath, realpath, join
 
-        ## Determine the path to the "data" directory of the neet.test module
+        # Determine the path to the "data" directory of the neet.test module
         DATA_PATH = join(dirname(abspath(realpath(__file__))), "data")
 
-        ## Test simple network read in (no header)
-        SIMPLE_TRUTH_TABLE = join(DATA_PATH, "test_simple_no_header-truth_table.txt")
+        # Test simple network read in (no header)
+        SIMPLE_TRUTH_TABLE = join(
+            DATA_PATH, "test_simple_no_header-truth_table.txt")
         with self.assertRaises(FormatError):
             simple = LogicNetwork.read_table(SIMPLE_TRUTH_TABLE)
 
     def test_logic_simple_read_no_node_headers(self):
         from os.path import dirname, abspath, realpath, join
 
-        ## Determine the path to the "data" directory of the neet.test module
+        # Determine the path to the "data" directory of the neet.test module
         DATA_PATH = join(dirname(abspath(realpath(__file__))), "data")
 
-        ## Test simple network read in (no header)
-        SIMPLE_TRUTH_TABLE = join(DATA_PATH, "test_simple_no_node_headers-truth_table.txt")
+        # Test simple network read in (no header)
+        SIMPLE_TRUTH_TABLE = join(
+            DATA_PATH, "test_simple_no_node_headers-truth_table.txt")
         with self.assertRaises(FormatError):
             simple = LogicNetwork.read_table(SIMPLE_TRUTH_TABLE)
 
     def test_logic_simple_read_empty(self):
         from os.path import dirname, abspath, realpath, join
 
-        ## Determine the path to the "data" directory of the neet.test module
+        # Determine the path to the "data" directory of the neet.test module
         DATA_PATH = join(dirname(abspath(realpath(__file__))), "data")
 
-        ## Test simple network read in (no header)
-        SIMPLE_TRUTH_TABLE = join(DATA_PATH, "test_simple_empty-truth_table.txt")
+        # Test simple network read in (no header)
+        SIMPLE_TRUTH_TABLE = join(
+            DATA_PATH, "test_simple_empty-truth_table.txt")
         simple = LogicNetwork.read_table(SIMPLE_TRUTH_TABLE)
 
         self.assertEqual(simple.names, ['A', 'B', 'C', 'D'])
-        self.assertEqual(simple.table, [((0,), set(['1'])), 
-                                        ((1,), set(['1'])), 
-                                        ((2,), set(['1'])), 
+        self.assertEqual(simple.table, [((0,), set(['1'])),
+                                        ((1,), set(['1'])),
+                                        ((2,), set(['1'])),
                                         ((3,), set(['1']))])
 
     def test_logic_simple_read_custom_comment(self):
         from os.path import dirname, abspath, realpath, join
 
-        ## Determine the path to the "data" directory of the neet.test module
+        # Determine the path to the "data" directory of the neet.test module
         DATA_PATH = join(dirname(abspath(realpath(__file__))), "data")
 
-        ## Test simple network read in (no header)
-        SIMPLE_TRUTH_TABLE = join(DATA_PATH, "test_simple_custom_comment-truth_table.txt")
+        # Test simple network read in (no header)
+        SIMPLE_TRUTH_TABLE = join(
+            DATA_PATH, "test_simple_custom_comment-truth_table.txt")
         simple = LogicNetwork.read_table(SIMPLE_TRUTH_TABLE)
 
         self.assertEqual(simple.names, ['A', 'B', 'C', 'D'])
-        self.assertEqual(simple.table, [((1, 2), set(['11', '10'])), 
-                                        ((0,), set(['1'])), 
-                                        ((1, 2, 0), set(['010', '011', '101'])), 
+        self.assertEqual(simple.table, [((1, 2), set(['11', '10'])),
+                                        ((0,), set(['1'])),
+                                        ((1, 2, 0), set(
+                                            ['010', '011', '101'])),
                                         ((3,), set(['1']))])
 
     def test_neighbors_in(self):
 
-        net = LogicNetwork([((1, 2), set(['11', '10'])), 
-                            ((0,), set(['1'])), 
-                            ((0, 1, 2), set(['010', '011', '101'])), 
+        net = LogicNetwork([((1, 2), set(['11', '10'])),
+                            ((0,), set(['1'])),
+                            ((0, 1, 2), set(['010', '011', '101'])),
                             ((3,), set(['1']))])
 
-        self.assertEqual(net.neighbors(index=2,direction='in'),set([0,1,2]))
+        self.assertEqual(net.neighbors(
+            index=2, direction='in'), set([0, 1, 2]))
 
-        self.assertEqual(net.neighbors(direction='in'),[set([1, 2]), 
-                                                        set([0]), 
-                                                        set([0, 1, 2]), 
-                                                        set([3])])
-
-        with self.assertRaises(TypeError):
-            self.assertEqual(net.neighbors(index=2.0,direction='in'))
+        self.assertEqual(net.neighbors(direction='in'), [set([1, 2]),
+                                                         set([0]),
+                                                         set([0, 1, 2]),
+                                                         set([3])])
 
         with self.assertRaises(TypeError):
-            self.assertEqual(net.neighbors(index='2',direction='in'))
+            self.assertEqual(net.neighbors(index=2.0, direction='in'))
+
+        with self.assertRaises(TypeError):
+            self.assertEqual(net.neighbors(index='2', direction='in'))
 
     def test_neighbors_out(self):
 
-        net = LogicNetwork([((1, 2), set(['11', '10'])), 
-                            ((0,), set(['1'])), 
-                            ((0, 1, 2), set(['010', '011', '101'])), 
+        net = LogicNetwork([((1, 2), set(['11', '10'])),
+                            ((0,), set(['1'])),
+                            ((0, 1, 2), set(['010', '011', '101'])),
                             ((3,), set(['1']))])
 
-        self.assertEqual(net.neighbors(index=2,direction='out'),set([0,2]))
+        self.assertEqual(net.neighbors(index=2, direction='out'), set([0, 2]))
 
-        self.assertEqual(net.neighbors(direction='out'),[set([1, 2]), 
-                                                         set([0, 2]), 
-                                                         set([0, 2]), 
-                                                         set([3])])
-       
-    def test_neighbors_both(self):
-        
-        net = LogicNetwork([((1, 2), set(['11', '10'])), 
-                            ((0,), set(['1'])), 
-                            ((0, 1, 2), set(['010', '011', '101'])), 
-                            ((3,), set(['1']))])
-
-        self.assertEqual(net.neighbors(direction='both'),[set([1, 2]), 
-                                                          set([0, 2]), 
-                                                          set([0, 1, 2]), 
+        self.assertEqual(net.neighbors(direction='out'), [set([1, 2]),
+                                                          set([0, 2]),
+                                                          set([0, 2]),
                                                           set([3])])
 
-        self.assertEqual(net.neighbors(index=2,direction='both'),set([0, 1, 2]))
+    def test_neighbors_both(self):
+
+        net = LogicNetwork([((1, 2), set(['11', '10'])),
+                            ((0,), set(['1'])),
+                            ((0, 1, 2), set(['010', '011', '101'])),
+                            ((3,), set(['1']))])
+
+        self.assertEqual(net.neighbors(direction='both'), [set([1, 2]),
+                                                           set([0, 2]),
+                                                           set([0, 1, 2]),
+                                                           set([3])])
+
+        self.assertEqual(net.neighbors(
+            index=2, direction='both'), set([0, 1, 2]))
 
     def test_node_dependency(self):
-        net = LogicNetwork([((1, 2), {'11', '10'}), 
-                            ((0,), {'1'}), 
+        net = LogicNetwork([((1, 2), {'11', '10'}),
+                            ((0,), {'1'}),
                             ((0, 1, 2), {'010', '011', '101', '100'})])
 
         self.assertTrue(net.is_dependent(0, 1))
@@ -232,11 +241,27 @@ class TestLogicNetwork(unittest.TestCase):
         self.assertTrue(net.is_dependent(2, 1))
 
     def test_reduce_table(self):
-        net = LogicNetwork([((1, 2), {'11', '10'}),
-                            ((0,), {'1'}),
-                            ((0, 1, 2), {'010', '011', '101', '100'})],
-                           reduced=True)
+        table = [((1, 2), {'11', '10'}),
+                 ((0,), {'1'}),
+                 ((0, 1, 2), {'010', '011', '101', '100'})]
+        net = LogicNetwork(table, reduced=True)
 
+        reduced_table = [((1,), {'1'}),
+                         ((0,), {'1'}),
+                         ((0, 1), {'01', '10'})]
+        self.assertEqual(net.table, reduced_table)
+
+        net = LogicNetwork(table)
+        self.assertEqual(net.table, table)
+        self.assertEqual(net._encoded_table,
+                         [(6, {6, 2}), (1, {1}), (7, {2, 6, 5, 1})])
+
+        net.reduce_table()
+        self.assertEqual(net.table, reduced_table)
+        self.assertEqual(net._encoded_table,
+                         [(2, {2}), (1, {1}), (3, {2, 1})])
+
+        net.reduce_table()
         self.assertEqual(net.table,
                          [((1,), {'1'}),
                           ((0,), {'1'}),


### PR DESCRIPTION
I implemented a function `is_dependent` for determining whether an input of a node in the truth table is a true connection, ie whether it has logic effect to the node. Another function `reduce_table` is for removing those 'false connections'. Also added is argument `reduced` for the `LogicNetwork`.