### PR TITLE
Sensitivity neighbors update

### DIFF
--- a/neet/automata/eca.py
+++ b/neet/automata/eca.py
@@ -654,19 +654,19 @@ class ECA(object):
             ValueError: index must be <size if self.boundary==None
         """
         if direction == 'in':
-            if index:
+            if index is not None:
                 return self._incoming_neighbors_one_node(size,index)
             else:
                 return [self._incoming_neighbors_one_node(size,node) for node in range(size)]
 
         if direction == 'out':
-            if index:
+            if index is not None:
                 return self._outgoing_neighbors_one_node(size,index)
             else:
                 return [self._outgoing_neighbors_one_node(size,node) for node in range(size)]
 
         if direction == 'both':
-            if index:
+            if index is not None:
                 return self._incoming_neighbors_one_node(size,index)|self._outgoing_neighbors_one_node(size,index)
                        
             else:

--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -617,19 +617,19 @@ class LogicNetwork(object):
             [set([1, 2]), set([0, 2]), set([0, 1, 2]), set([3])]
         """
         if direction == 'in':
-            if index:
+            if index is not None:
                 return self._incoming_neighbors_one_node(index)
             else:
                 return [self._incoming_neighbors_one_node(node) for node in range(len(self.table))]
 
         elif direction == 'out':
-            if index:
+            if index is not None:
                 return self._outgoing_neighbors_one_node(index)
             else:
                 return [self._outgoing_neighbors_one_node(node) for node in range(len(self.table))]
 
         elif direction == 'both':
-            if index:
+            if index is not None:
                 return self._incoming_neighbors_one_node(index) | self._outgoing_neighbors_one_node(index)
 
             else:

--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -607,7 +607,10 @@ class WTNetwork(object):
             >>> net._incoming_neighbors_one_node(2)
             set([0, 1, 5, 8])
         """
-        return set([i for i,e in enumerate(self.weights[index,:]) if e!=0])
+        if self.theta is type(self).split_threshold:
+            return set([i for i,e in enumerate(self.weights[index,:]) if e!=0 or i==index])
+        else:
+            return set([i for i,e in enumerate(self.weights[index,:]) if e!=0])
 
     def _outgoing_neighbors_one_node(self,index):
         """
@@ -635,7 +638,10 @@ class WTNetwork(object):
             >>> net._outgoing_neighbors_one_node(2)
             set([1, 5])
         """
-        return set([i for i,e in enumerate(self.weights[:,index]) if e!=0])
+        if self.theta is type(self).split_threshold:
+            return set([i for i,e in enumerate(self.weights[:,index]) if e!=0 or i==index])
+        else:
+            return set([i for i,e in enumerate(self.weights[:,index]) if e!=0])
         # outgoing_neighbors = []
         # for i, incoming_neighbors in enumerate([list(row[0]) for row in self.table]):
         #     if index in incoming_neighbors:

--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -704,19 +704,19 @@ class WTNetwork(object):
              set([2, 3, 4, 6, 7, 8])]
         """
         if direction == 'in':
-            if index:
+            if index is not None:
                 return self._incoming_neighbors_one_node(index)
             else:
                 return [self._incoming_neighbors_one_node(node) for node in range(self.size)]
 
         if direction == 'out':
-            if index:
+            if index is not None:
                 return self._outgoing_neighbors_one_node(index)
             else:
                 return [self._outgoing_neighbors_one_node(node) for node in range(self.size)]
 
         if direction == 'both':
-            if index:
+            if index is not None:
                 return self._incoming_neighbors_one_node(index)|self._outgoing_neighbors_one_node(index)
                        
             else:

--- a/neet/sensitivity.py
+++ b/neet/sensitivity.py
@@ -102,7 +102,7 @@ def average_difference_matrix(net,states=None,weights=None,calc_trans=True):
                           Otherwise, providing a list of states will calculate 
                           the average over only those states.
     calc_trans (True)   : Optionally pre-calculate all transitions.  Only used
-                          when states argument is not None.
+                          when states or weights argument is not None.
     """
     N = net.size
     Q = np.zeros((N,N))

--- a/neet/sensitivity.py
+++ b/neet/sensitivity.py
@@ -91,9 +91,6 @@ def _states_limited(nodes,state0):
         stateFlipped[nodes[0]] = (stateFlipped[nodes[0]]+1)%2
         return _states_limited(nodes[1:],state0) + _states_limited(nodes[1:],stateFlipped)
 
-def _connections(net,nodei):
-    return net.table[nodei][0]
-
 def average_difference_matrix(net,states=None,weights=None,calc_trans=True):
     """
     Averaged over states, what is the probability
@@ -110,7 +107,7 @@ def average_difference_matrix(net,states=None,weights=None,calc_trans=True):
     N = net.size
     Q = np.zeros((N,N))
 
-    if (states is not None) or (weights is not None) or (not hasattr(net,'table')):
+    if (states is not None) or (weights is not None):
         # explicitly calculate difference matrix for each state
     
         # optionally pre-calculate transitions
@@ -142,7 +139,7 @@ def average_difference_matrix(net,states=None,weights=None,calc_trans=True):
         state0 = np.zeros(N,dtype=int)
 
         for i in range(N):
-            nodesInfluencingI = _connections(net,i)
+            nodesInfluencingI = list(net.neighbors(index=i,direction='in'))
             for jindex,j in enumerate(nodesInfluencingI):
             
                 # for each state of other nodes, does j matter?

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -94,9 +94,11 @@ class TestCore(unittest.TestCase):
         eca = ca.ECA(30)
 
         self.assertEqual(neighbors(eca,size=4),[set([0, 1, 3]),
-                                               set([0, 1, 2]), 
-                                               set([1, 2, 3]), 
-                                               set([0, 2, 3])])
+                                                set([0, 1, 2]),
+                                                set([1, 2, 3]),
+                                                set([0, 2, 3])])
+        # test kwargs
+        self.assertEqual(neighbors(eca,size=4,index=0),set([0, 1, 3]))
 
         with self.assertRaises(AttributeError):
             neighbors(eca)

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -102,14 +102,26 @@ class TestCore(unittest.TestCase):
             neighbors(eca)
 
     def test_neighbors_WTNetwork(self):
-        net = bnet.WTNetwork([[1]])
+        net = bnet.WTNetwork([[1,0],[1,1]])
 
-        self.assertTrue(neighbors(net),[set([0])])
+        self.assertEqual(neighbors(net),[set([0,1]),set([0,1])])
+        # test kwargs
+        self.assertEqual(neighbors(net,direction='in'),
+                        [set([0]),set([0,1])])
+        self.assertEqual(neighbors(net,direction='out'),
+                        [set([0,1]),set([1])])
+        self.assertEqual(neighbors(net,index=0),set([0,1]))
 
     def test_neighbors_LogicNetwork(self):
-        net = bnet.LogicNetwork([((0,), {'0'})])
+        net = bnet.LogicNetwork([((0,1), {'00', '11'}), ((1,), {'1'})])
 
-        self.assertTrue(neighbors(net),[set([0])])
+        self.assertEqual(neighbors(net),[set([0,1]),set([0,1])])
+        # test kwargs
+        self.assertEqual(neighbors(net,direction='in'),
+                         [set([0,1]),set([1])])
+        self.assertEqual(neighbors(net,direction='out'),
+                         [set([0]),set([0,1])])
+        self.assertEqual(neighbors(net,index=0),set([0,1]))
 
     def test_neighbors_IsNetwork(self):
         net = self.IsNetwork()

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -93,7 +93,7 @@ class TestCore(unittest.TestCase):
     def test_neighbors_ECA(self):
         eca = ca.ECA(30)
 
-        self.assertTrue(neighbors(eca,size=4),[set([0, 1, 3]), 
+        self.assertEqual(neighbors(eca,size=4),[set([0, 1, 3]),
                                                set([0, 1, 2]), 
                                                set([1, 2, 3]), 
                                                set([0, 2, 3])])


### PR DESCRIPTION
This addresses issue #86 , implementing the sensitivity functions using the neighbors function, so that WTNetworks can profit from the same efficiency as LogicNetworks when their connectivity is sparse.

Important: To make this work, I also had to slightly change the logic of the WTNetwork neighbors function.  When the WTNetwork uses the "split_threshold" function (which is the default), the future state of a node can depend on its current state when its incoming signals sum to zero.  (This happens even if the node has no incoming weight from itself.)  For this reason, I changed the neighbors function to always include all self-links if the network uses split thresholding.  Someone who has more experience with weight-threshold networks should think about this and make sure it makes sense.  For this reason, this pull request will fail existing tests on the neighbors function until we decide what to do.

This also fixes a bug with the neighbors "index" argument when index=0.