### PR TITLE
Changes to the design of `neighbors` series functions

### DIFF
--- a/neet/automata/eca.py
+++ b/neet/automata/eca.py
@@ -351,7 +351,7 @@ class ECA(object):
 
         return self._unsafe_update(lattice, index, pin, values)
 
-    def incoming_neighbors(self, index, size):
+    def neighbors_in(self, index, size):
         """
         Return the set of all incoming neighbor nodes.
 
@@ -372,14 +372,14 @@ class ECA(object):
         ::
 
             >>> net = ECA(30)
-            >>> net.incoming_neighbors(1, size=3)
+            >>> net.neighbors_in(1, size=3)
             set([0, 1, 2])
-            >>> net.incoming_neighbors(2, size=3)
+            >>> net.neighbors_in(2, size=3)
             set([0, 1, 2])
             >>> net.boundary = (1,1)
-            >>> net.incoming_neighbors(2, size=3)
+            >>> net.neighbors_in(2, size=3)
             set([1, 2, 3])
-            >>> net.incoming_neighbors(0, 3)
+            >>> net.neighbors_in(0, 3)
             set([-1, 0, 1])
 
         .. rubric:: Erroneous Usage:
@@ -387,7 +387,7 @@ class ECA(object):
         ::
 
             >>> net = ECA(30,boundary=(1, 1))
-            >>> net.incoming_neighbors(5, 3)
+            >>> net.neighbors_in(5, 3)
             Traceback (most recent call last):
                 ...
             ValueError: index must be a non-negative integer less than size
@@ -414,7 +414,7 @@ class ECA(object):
 
         return set([left, index, right])
 
-    def outgoing_neighbors(self, index, size):
+    def neighbors_out(self, index, size):
         """
         Return the set of all outgoing neighbor nodes.
 
@@ -430,14 +430,14 @@ class ECA(object):
         ::
 
             >>> net = ECA(30)
-            >>> net.outgoing_neighbors(1, 3)
+            >>> net.neighbors_out(1, 3)
             set([0, 1, 2])
-            >>> net.outgoing_neighbors(2, 3)
+            >>> net.neighbors_out(2, 3)
             set([0, 1, 2])
             >>> net.boundary = (1, 1)
-            >>> net.outgoing_neighbors(2, 3)
+            >>> net.neighbors_out(2, 3)
             set([1, 2])
-            >>> net.outgoing_beighbors(0, 3)
+            >>> net.neighbors_out(0, 3)
             set([0, 1])
 
         .. rubric:: Erroneous Usage:
@@ -445,7 +445,7 @@ class ECA(object):
         ::
 
             >>> net = ECA(30,boundary=(1, 1))
-            >>> net.incoming_neighbors(5, 3)
+            >>> net.neighbors_out(5, 3)
             Traceback (most recent call last):
                 ...
             ValueError: index must be a non-negative integer less than size
@@ -493,14 +493,14 @@ class ECA(object):
         ::
 
             >>> net = ECA(30)
-            >>> net.incoming_neighbors(1, size=3)
+            >>> net.neighbors(1, size=3)
             set([0, 1, 2])
-            >>> net.incoming_neighbors(2, size=3)
+            >>> net.neighbors(2, size=3)
             set([0, 1, 2])
             >>> net.boundary = (1,1)
-            >>> net.incoming_neighbors(2, size=3)
+            >>> net.neighbors(2, size=3)
             set([1, 2, 3])
-            >>> net.incoming_neighbors(0, 3)
+            >>> net.neighbors(0, 3)
             set([-1, 0, 1])
 
         .. rubric:: Erroneous Usage:
@@ -508,10 +508,10 @@ class ECA(object):
         ::
 
             >>> net = ECA(30,boundary=(1, 1))
-            >>> net.incoming_neighbors(5, 3)
+            >>> net.neighbors(5, 3)
             Traceback (most recent call last):
                 ...
             ValueError: index must be a non-negative integer less than size
         """
         # Outgoing neighbors are a subset of incoming neighbors.
-        return self.incoming_neighbors(index, size)
+        return self.neighbors_in(index, size)

--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -598,7 +598,6 @@ class LogicNetwork(object):
         neighbors for all nodes in the network.
 
         :param index: node index
-        :param direction: type of node neighbors to return (can be 'in','out', or 'both')
         :returns: a set of neighbors of a node
 
         .. rubric:: Basic Use:
@@ -612,4 +611,4 @@ class LogicNetwork(object):
             >>> net.neighbors(2)
             set([0, 2])
         """
-        return self.neighbors_in(index) | self.neighbors_in(index)
+        return self.neighbors_in(index) | self.neighbors_out(index)

--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -545,7 +545,7 @@ class LogicNetwork(object):
     #     else:
     #         return [list(row[0]) for row in self.table]
 
-    def incoming_neighbors(self, index):
+    def neighbors_in(self, index):
         """
         Return the set of all neighbor nodes, where
         edge(neighbor_node-->index) exists.
@@ -561,12 +561,12 @@ class LogicNetwork(object):
                             ((0,), set(['1'])),
                             ((0, 1, 2), set(['010', '011', '101'])),
                             ((3,), set(['1']))])
-            >>> net.incoming_neighbors(2)
+            >>> net.neighbors_in(2)
             set([0, 1, 2])
         """
         return set(self.table[index][0])
 
-    def outgoing_neighbors(self, index):
+    def neighbors_out(self, index):
         """
         Return the set of all neighbor nodes, where
         edge(index-->neighbor_node) exists.
@@ -582,15 +582,15 @@ class LogicNetwork(object):
                             ((0,), set(['1'])),
                             ((0, 1, 2), set(['010', '011', '101'])),
                             ((3,), set(['1']))])
-            >>> net.outgoing_neighbors(2)
+            >>> net.neighbors_out(2)
             set([0, 2])
         """
-        outgoing_neighbors = []
+        outgoing_neighbors = set()
         for i, incoming_neighbors in enumerate([row[0] for row in self.table]):
             if index in incoming_neighbors:
-                outgoing_neighbors.append(i)
+                outgoing_neighbors.add(i)
 
-        return set(outgoing_neighbors)
+        return outgoing_neighbors
 
     def neighbors(self, index):
         """
@@ -612,4 +612,4 @@ class LogicNetwork(object):
             >>> net.neighbors(2)
             set([0, 2])
         """
-        return self.incoming_neighbors(index) | self.outgoing_neighbors(index)
+        return self.neighbors_in(index) | self.neighbors_in(index)

--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -545,7 +545,7 @@ class LogicNetwork(object):
     #     else:
     #         return [list(row[0]) for row in self.table]
 
-    def _incoming_neighbors_one_node(self, index):
+    def incoming_neighbors(self, index):
         """
         Return the set of all neighbor nodes, where
         edge(neighbor_node-->index) exists.
@@ -557,16 +557,16 @@ class LogicNetwork(object):
 
         ::
 
-            >>> net = LogicNetwork([((1, 2), set(['11', '10'])), 
-                            ((0,), set(['1'])), 
-                            ((0, 1, 2), set(['010', '011', '101'])), 
+            >>> net = LogicNetwork([((1, 2), set(['11', '10'])),
+                            ((0,), set(['1'])),
+                            ((0, 1, 2), set(['010', '011', '101'])),
                             ((3,), set(['1']))])
-            >>> net._incoming_neighbors_one_node(2)
+            >>> net.incoming_neighbors(2)
             set([0, 1, 2])
         """
         return set(self.table[index][0])
 
-    def _outgoing_neighbors_one_node(self, index):
+    def outgoing_neighbors(self, index):
         """
         Return the set of all neighbor nodes, where
         edge(index-->neighbor_node) exists.
@@ -578,28 +578,28 @@ class LogicNetwork(object):
 
         ::
 
-            >>> net = LogicNetwork([((1, 2), set(['11', '10'])), 
-                            ((0,), set(['1'])), 
-                            ((0, 1, 2), set(['010', '011', '101'])), 
+            >>> net = LogicNetwork([((1, 2), set(['11', '10'])),
+                            ((0,), set(['1'])),
+                            ((0, 1, 2), set(['010', '011', '101'])),
                             ((3,), set(['1']))])
-            >>> net._outgoing_neighbors_one_node(2)
+            >>> net.outgoing_neighbors(2)
             set([0, 2])
         """
         outgoing_neighbors = []
-        for i, incoming_neighbors in enumerate([list(row[0]) for row in self.table]):
+        for i, incoming_neighbors in enumerate([row[0] for row in self.table]):
             if index in incoming_neighbors:
                 outgoing_neighbors.append(i)
 
         return set(outgoing_neighbors)
 
-    def neighbors(self, index=None, direction='both'):
+    def neighbors(self, index):
         """
         Return a set of neighbors for a specified node, or a list of sets of
         neighbors for all nodes in the network.
 
         :param index: node index
         :param direction: type of node neighbors to return (can be 'in','out', or 'both')
-        :returns: a set (if index!=None) or list of sets of neighbors of a node or network or nodes
+        :returns: a set of neighbors of a node
 
         .. rubric:: Basic Use:
 
@@ -609,35 +609,7 @@ class LogicNetwork(object):
                             ((0,), set(['1'])), 
                             ((0, 1, 2), set(['010', '011', '101'])), 
                             ((3,), set(['1']))])
-            >>> net.neighbors(index=2,direction='in')
-            set([0,1,2])
-            >>> net.neighbors(index=2,direction='out'),set([0,2])
-            >>> net.neighbors(direction='in')
-            [set([1, 2]), set([0]), set([0, 1, 2]), set([3])]
-            >>> net.neighbors(direction='out')
-            [set([1, 2]), set([0, 2]), set([0, 2]), set([3])]
-            >>> net.neighbors(direction='both')
-            [set([1, 2]), set([0, 2]), set([0, 1, 2]), set([3])]
+            >>> net.neighbors(2)
+            set([0,2])
         """
-        if direction == 'in':
-            if index:
-                return self._incoming_neighbors_one_node(index)
-            else:
-                return [self._incoming_neighbors_one_node(node) for node in range(len(self.table))]
-
-        elif direction == 'out':
-            if index:
-                return self._outgoing_neighbors_one_node(index)
-            else:
-                return [self._outgoing_neighbors_one_node(node) for node in range(len(self.table))]
-
-        elif direction == 'both':
-            if index:
-                return self._incoming_neighbors_one_node(index) | self._outgoing_neighbors_one_node(index)
-
-            else:
-                in_nodes = [self._incoming_neighbors_one_node(
-                    node) for node in range(len(self.table))]
-                out_nodes = [self._outgoing_neighbors_one_node(
-                    node) for node in range(len(self.table))]
-                return [in_nodes[i] | out_nodes[i] for i in range(len(in_nodes))]
+        return self.incoming_neighbors(index) | self.outgoing_neighbors(index)

--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -605,11 +605,11 @@ class LogicNetwork(object):
 
         ::
 
-            >>> net = LogicNetwork([((1, 2), set(['11', '10'])), 
-                            ((0,), set(['1'])), 
-                            ((0, 1, 2), set(['010', '011', '101'])), 
+            >>> net = LogicNetwork([((1, 2), set(['11', '10'])),
+                            ((0,), set(['1'])),
+                            ((0, 1, 2), set(['010', '011', '101'])),
                             ((3,), set(['1']))])
             >>> net.neighbors(2)
-            set([0,2])
+            set([0, 2])
         """
         return self.incoming_neighbors(index) | self.outgoing_neighbors(index)

--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -644,7 +644,6 @@ class WTNetwork(object):
         neighbors for all nodes in the network.
 
         :param index: node index
-        :param direction: type of node neighbors to return (can be 'in','out', or 'both')
         :returns: a set (if index!=None) or list of sets of neighbors of a node or network or nodes
 
         .. rubric:: Basic Use:

--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -582,7 +582,7 @@ class WTNetwork(object):
             else:
                 return 1
 
-    def incoming_neighbors(self, index):
+    def neighbors_in(self, index):
         """
         Return the set of all neighbor nodes, where
         edge(neighbor_node-->index) exists.
@@ -603,13 +603,14 @@ class WTNetwork(object):
              [ 0.0, 0.0,-1.0,-1.0,-1.0, 0.0,-1.0, 1.0, 0.0],
              [ 0.0,-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
              [ 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,-1.0],
-             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]])
-            >>> net.incoming_neighbors(2)
+             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]],
+            [ 0.0,-0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0])
+            >>> net.neighbors_in(2)
             set([0, 1, 5, 8])
         """
         return set(np.flatnonzero(self.weights[index]))
 
-    def outgoing_neighbors(self, index):
+    def neighbors_out(self, index):
         """
         Return the set of all neighbor nodes, where
         edge(index-->neighbor_node) exists.
@@ -630,8 +631,9 @@ class WTNetwork(object):
              [ 0.0, 0.0,-1.0,-1.0,-1.0, 0.0,-1.0, 1.0, 0.0],
              [ 0.0,-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
              [ 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,-1.0],
-             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]])
-            >>> net.outgoing_neighbors(2)
+             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]],
+            [ 0.0,-0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0])
+            >>> net.neighbors_out(2)
             set([1, 5])
         """
         return set(np.flatnonzero(self.weights[:, index]))
@@ -658,8 +660,9 @@ class WTNetwork(object):
              [ 0.0, 0.0,-1.0,-1.0,-1.0, 0.0,-1.0, 1.0, 0.0],
              [ 0.0,-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
              [ 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,-1.0],
-             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]])
+             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]],
+            [ 0.0,-0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0])
             >>> net.neighbors(2)
             set([0, 1, 5, 8])
         """
-        return self.incoming_neighbors(index) | self.outgoing_neighbors(index)
+        return self.neighbors_in(index) | self.neighbors_out(index)

--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -5,6 +5,7 @@ import numpy as np
 import re
 from neet.statespace import StateSpace
 
+
 class WTNetwork(object):
     """
     The WTNetwork class represents weight/threshold-based boolean networks. As
@@ -12,6 +13,7 @@ class WTNetwork(object):
     node thresholds, and each node of the network is expected to be in either
     of two states ``0`` or ``1``.
     """
+
     def __init__(self, weights, thresholds=None, names=None, theta=None):
         """
         Construct a network from weights and thresholds.
@@ -64,10 +66,10 @@ class WTNetwork(object):
         :raises TypeError: if ``threshold_func`` is not callable
         """
         if isinstance(weights, int):
-            self.weights = np.zeros([weights,weights])
+            self.weights = np.zeros([weights, weights])
         else:
             self.weights = np.asarray(weights, dtype=np.float)
-        
+
         shape = self.weights.shape
         if self.weights.ndim != 2:
             raise(ValueError("weights must be a matrix"))
@@ -239,7 +241,6 @@ class WTNetwork(object):
                 states[key] = values[key]
         return states
 
-
     def update(self, states, index=None, pin=None, values=None):
         """
         Update ``states``, in place, according to the network update rules.
@@ -390,12 +391,12 @@ class WTNetwork(object):
                     index += 1
 
         n = len(names)
-        weights = np.zeros((n,n), dtype=np.float)
+        weights = np.zeros((n, n), dtype=np.float)
         with open(edges_file, "r") as f:
             for line in f.readlines():
                 if comment.match(line) is None:
                     a, b, w = line.strip().split()
-                    weights[nameindices[b],nameindices[a]] = float(w)
+                    weights[nameindices[b], nameindices[a]] = float(w)
 
         return WTNetwork(weights, thresholds, names)
 
@@ -581,7 +582,7 @@ class WTNetwork(object):
             else:
                 return 1
 
-    def _incoming_neighbors_one_node(self,index):
+    def incoming_neighbors(self, index):
         """
         Return the set of all neighbor nodes, where
         edge(neighbor_node-->index) exists.
@@ -602,18 +603,17 @@ class WTNetwork(object):
              [ 0.0, 0.0,-1.0,-1.0,-1.0, 0.0,-1.0, 1.0, 0.0],
              [ 0.0,-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
              [ 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,-1.0],
-             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]],
-            [ 0.0,-0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0])
-            >>> net._incoming_neighbors_one_node(2)
+             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]])
+            >>> net.incoming_neighbors(2)
             set([0, 1, 5, 8])
         """
-        return set([i for i,e in enumerate(self.weights[index,:]) if e!=0])
+        return set(np.flatnonzero(self.weights[index]))
 
-    def _outgoing_neighbors_one_node(self,index):
+    def outgoing_neighbors(self, index):
         """
         Return the set of all neighbor nodes, where
         edge(index-->neighbor_node) exists.
-        
+
         :param index: node index
         :returns: the set of all node indices which the index node points to
 
@@ -630,25 +630,17 @@ class WTNetwork(object):
              [ 0.0, 0.0,-1.0,-1.0,-1.0, 0.0,-1.0, 1.0, 0.0],
              [ 0.0,-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
              [ 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,-1.0],
-             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]],
-            [ 0.0,-0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0])
-            >>> net._outgoing_neighbors_one_node(2)
+             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]])
+            >>> net.outgoing_neighbors(2)
             set([1, 5])
         """
-        return set([i for i,e in enumerate(self.weights[:,index]) if e!=0])
-        # outgoing_neighbors = []
-        # for i, incoming_neighbors in enumerate([list(row[0]) for row in self.table]):
-        #     if index in incoming_neighbors:
-        #         outgoing_neighbors.append(i)
-        
-        # return set(outgoing_neighbors)
+        return set(np.flatnonzero(self.weights[:, index]))
 
-
-    def neighbors(self,index=None,direction='both'):
+    def neighbors(self, index):
         """
         Return a set of neighbors for a specified node, or a list of sets of
         neighbors for all nodes in the network.
-        
+
         :param index: node index
         :param direction: type of node neighbors to return (can be 'in','out', or 'both')
         :returns: a set (if index!=None) or list of sets of neighbors of a node or network or nodes
@@ -666,60 +658,8 @@ class WTNetwork(object):
              [ 0.0, 0.0,-1.0,-1.0,-1.0, 0.0,-1.0, 1.0, 0.0],
              [ 0.0,-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
              [ 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,-1.0],
-             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]],
-            [ 0.0,-0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0])
-            >>> net.neighbors(index=2,direction='in')
-            set([0,1,5,8])
-            >>> net.neighbors(index=2,direction='out')
-            set([1,5])
-            >>> net.neighbors(direction='in')
-            [set([0]), 
-            set([2, 3, 4]), 
-            set([0, 1, 5, 8]), 
-            set([0, 1, 5, 8]), 
-            set([4, 5]), 
-            set([2, 3, 4, 6, 7]), 
-            set([8, 1]), 
-            set([8, 1]), 
-            set([8, 4])]
-            >>> net.neighbors(direction='out')
-            [set([0, 2, 3]), 
-             set([2, 3, 6, 7]), 
-             set([1, 5]), 
-             set([1, 5]), 
-             set([8, 1, 4, 5]), 
-             set([2, 3, 4]), 
-             set([5]), 
-             set([5]), 
-             set([8, 2, 3, 6, 7])]
-            >>> net.neighbors(direction='both')
-            [set([0, 2, 3]), 
-             set([2, 3, 4, 6, 7]), 
-             set([0, 1, 5, 8]), 
-             set([0, 1, 5, 8]), 
-             set([1, 4, 5, 8]), 
-             set([2, 3, 4, 6, 7]), 
-             set([8, 1, 5]), 
-             set([8, 1, 5]), 
-             set([2, 3, 4, 6, 7, 8])]
+             [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]])
+            >>> net.neighbors(2)
+            set([0, 1, 5, 8])
         """
-        if direction == 'in':
-            if index:
-                return self._incoming_neighbors_one_node(index)
-            else:
-                return [self._incoming_neighbors_one_node(node) for node in range(self.size)]
-
-        if direction == 'out':
-            if index:
-                return self._outgoing_neighbors_one_node(index)
-            else:
-                return [self._outgoing_neighbors_one_node(node) for node in range(self.size)]
-
-        if direction == 'both':
-            if index:
-                return self._incoming_neighbors_one_node(index)|self._outgoing_neighbors_one_node(index)
-                       
-            else:
-                in_nodes = [self._incoming_neighbors_one_node(node) for node in range(self.size)]
-                out_nodes = [self._outgoing_neighbors_one_node(node) for node in range(self.size)]
-                return [in_nodes[i]|out_nodes[i] for i in range(self.size)]
+        return self.incoming_neighbors(index) | self.outgoing_neighbors(index)

--- a/neet/interfaces.py
+++ b/neet/interfaces.py
@@ -76,28 +76,22 @@ def is_boolean_network(thing):
     return is_network(thing) and hasattr(thing.state_space(), 'base') and thing.state_space().base == 2
 
 
-def neighbors(net, index=None, direction='both', **kwargs):
+def neighbors(net, index, direction='both', **kwargs):
     """
     Return a set of neighbors for a specified node, or a list of sets of
     neighbors for all nodes in the network.
 
-    For ECAs it is possible to call the neighbors of an index which is
-    greater than the size of the network, in the case of networks which have
-    fixed boundary conditions.
-
-    The left boundary is at ``index==size+1``
-    The right boundary is at ``index==size``
-
-    eg. ``if size(eca)==3 and boundary!=None:``
-    The organization of the neighbors list is as follows:
-    ``[node_0|node_1|node_2|left_boundary|right_boundary]``
+    For ECAs, in the cases of the lattices having fixed boundary conditions,
+    the left boundary, being on the left of the leftmost index 0, has an index
+    of -1, while the right boundary's index is the size+1. The full state of the
+    lattices and the boundaries is equavolent to:
+    `[cell0, cell1, ..., cellN, right_boundary, left_boundary]`
+    if it is ever presented as a single list in Python.
 
     :param index: node index, if neighbors desired for one node only
     :param direction: type of node neighbors to return (can be 'in','out', or 'both')
     :kwarg size: size of ECA, required if network is an ECA
-    :returns: a set (if index!=None) or list of sets of neighbors of a node or network or nodes
-    :raises ValueError: if ``net.__class__.__name__ == 'ECA' and index >= size and boundary==None``
-    :raises ValueError: if ``net.__class__.__name__ == 'ECA' and index >= size+2 and boundary!=None``
+    :returns: a set of neighbors of a node
 
     .. rubric:: Basic Use:
 

--- a/neet/interfaces.py
+++ b/neet/interfaces.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a MIT
 # license that can be found in the LICENSE file.
 
+
 def is_network(thing):
     """
     Determine whether an *object* or *type* meets the interface requirement of
@@ -74,12 +75,13 @@ def is_boolean_network(thing):
     # Boolean networks have a single base equal to 2
     return is_network(thing) and hasattr(thing.state_space(), 'base') and thing.state_space().base == 2
 
-def neighbors(net,index=None,direction='both',**kwargs):
+
+def neighbors(net, index=None, direction='both', **kwargs):
     """
     Return a set of neighbors for a specified node, or a list of sets of
     neighbors for all nodes in the network.
 
-    For ECAs it is possible to call the neighbors of an index which is 
+    For ECAs it is possible to call the neighbors of an index which is
     greater than the size of the network, in the case of networks which have
     fixed boundary conditions.
 
@@ -89,7 +91,7 @@ def neighbors(net,index=None,direction='both',**kwargs):
     eg. ``if size(eca)==3 and boundary!=None:``
     The organization of the neighbors list is as follows:
     ``[node_0|node_1|node_2|left_boundary|right_boundary]``
-    
+
     :param index: node index, if neighbors desired for one node only
     :param direction: type of node neighbors to return (can be 'in','out', or 'both')
     :kwarg size: size of ECA, required if network is an ECA
@@ -112,13 +114,18 @@ def neighbors(net,index=None,direction='both',**kwargs):
     docstrings for more details and basic use examples.
 
     """
+    if direction not in ('in', 'out', 'both'):
+        raise ValueError('direction must be "in", "out" or "both"')
+
+    neighbor_types = {'in': net.neighbors_in,
+                      'out': net.neighbors_out,
+                      'both': net.neighbors}
 
     if net.__class__.__name__ == 'ECA':
-
         if 'size' not in kwargs:
             raise AttributeError("A `size` kwarg is required for returning an ECA's neighbors")
         else:
-            return net.neighbors(kwargs['size'],index=index,direction=direction)
+            return neighbor_types[direction](index, size=kwargs['size'])
 
     else:
-        return net.neighbors(index=index,direction=direction)
+        return neighbor_types[direction](index)

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -653,23 +653,13 @@ class TestWTNetwork(unittest.TestCase):
              [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]],
             [ 0.0,-0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0])
 
-        self.assertEqual(net.neighbors(index=2,direction='in'),set([0,1,5,8]))
-        
-        self.assertEqual(net.neighbors(direction='in'),[set([0]), 
-                                                        set([2, 3, 4]), 
-                                                        set([0, 1, 5, 8]), 
-                                                        set([0, 1, 5, 8]), 
-                                                        set([4, 5]), 
-                                                        set([2, 3, 4, 6, 7]), 
-                                                        set([8, 1]), 
-                                                        set([8, 1]), 
-                                                        set([8, 4])])
+        self.assertEqual(net.neighbors_in(2),set([0,1,5,8]))
 
         with self.assertRaises(IndexError):
-            self.assertEqual(net.neighbors(index=2.0,direction='in'))
+            self.assertEqual(net.neighbors_in(2.0))
 
         with self.assertRaises(IndexError):
-            self.assertEqual(net.neighbors(index='2',direction='in'))
+            self.assertEqual(net.neighbors_in('2'))
 
     def test_neighbors_out(self):
 
@@ -685,17 +675,7 @@ class TestWTNetwork(unittest.TestCase):
              [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]],
             [ 0.0,-0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0])
 
-        self.assertEqual(net.neighbors(index=2,direction='out'),set([1,5]))
-
-        self.assertEqual(net.neighbors(direction='out'),[set([0, 2, 3]), 
-                                                         set([2, 3, 6, 7]), 
-                                                         set([1, 5]), 
-                                                         set([1, 5]), 
-                                                         set([8, 1, 4, 5]), 
-                                                         set([2, 3, 4]), 
-                                                         set([5]), 
-                                                         set([5]), 
-                                                         set([8, 2, 3, 6, 7])])
+        self.assertEqual(net.neighbors_out(2),set([1,5]))
       
     def test_neighbors_both(self):
 
@@ -711,17 +691,7 @@ class TestWTNetwork(unittest.TestCase):
              [ 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,-1.0]],
             [ 0.0,-0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0])
 
-        self.assertEqual(net.neighbors(index=2,direction='both'),set([0, 1, 5, 8]))
-
-        self.assertEqual(net.neighbors(direction='both'),[set([0, 2, 3]), 
-                                                          set([2, 3, 4, 6, 7]), 
-                                                          set([0, 1, 5, 8]), 
-                                                          set([0, 1, 5, 8]), 
-                                                          set([1, 4, 5, 8]), 
-                                                          set([2, 3, 4, 6, 7]), 
-                                                          set([8, 1, 5]), 
-                                                          set([8, 1, 5]), 
-                                                          set([2, 3, 4, 6, 7, 8])])
+        self.assertEqual(net.neighbors(2),set([0, 1, 5, 8]))
 
         
 

--- a/test/test_eca.py
+++ b/test/test_eca.py
@@ -346,79 +346,59 @@ class TestECA(unittest.TestCase):
 
         net = ca.ECA(30)
 
-        self.assertEqual(net.neighbors(3,index=2,direction='in'),set([0,1,2]))
-        self.assertEqual(net.neighbors(3,direction='in'),[set([0, 1, 2]),  
-                                                        set([0, 1, 2]), 
-                                                        set([0, 1, 2])])
+        self.assertEqual(net.neighbors_in(2, size=3),set([0,1,2]))
+
         with self.assertRaises(ValueError):
-            self.assertEqual(net.neighbors(3,index=3,direction='in'))
+            self.assertEqual(net.neighbors_in(3, 3))
 
         net.boundary = (1,1)
 
-        self.assertEqual(net.neighbors(3,index=2,direction='in'),set([1,2,3]))
-        self.assertEqual(net.neighbors(3,index=3,direction='in'),set([]))
-
+        self.assertEqual(net.neighbors_in(2, 3),set([1,2,3]))
 
         with self.assertRaises(ValueError):
-            self.assertEqual(net.neighbors(3,index=5,direction='in'))
+            self.assertEqual(net.neighbors_in(3, 3))
+
+        with self.assertRaises(ValueError):
+            self.assertEqual(net.neighbors_in(5, 3))
 
         with self.assertRaises(TypeError):
-            self.assertEqual(net.neighbors(3,index='2',direction='in'))
+            self.assertEqual(net.neighbors_in('2', 3))
 
         with self.assertRaises(ValueError):
-            self.assertEqual(net.neighbors(3,index=-1,direction='in'))
+            self.assertEqual(net.neighbors_in(-1, 3))
 
         with self.assertRaises(ValueError):
-            self.assertEqual(net.neighbors(0,index=1,direction='in'))
-
+            self.assertEqual(net.neighbors_in(1, 0))
 
     def test_neighbors_out(self):
 
         net = ca.ECA(30)
 
-        self.assertEqual(net.neighbors(3,index=2,direction='out'),set([0,1,2]))
-        self.assertEqual(net.neighbors(4,direction='out'),[set([0, 1, 3]), 
-                                                         set([0,1,2]), 
-                                                         set([1,2,3]), 
-                                                         set([0,2,3])])
+        self.assertEqual(net.neighbors_out(2, 3),set([0,1,2]))
 
         with self.assertRaises(ValueError):
-            self.assertEqual(net.neighbors(3,index=3,direction='out'))
+            self.assertEqual(net.neighbors_out(3, 3))
 
         net.boundary = (1,1)
 
-        self.assertEqual(net.neighbors(3,index=2,direction='out'),set([1,2]))
-        self.assertEqual(net.neighbors(3,index=3,direction='out'),set([2]))
-        self.assertEqual(net.neighbors(3,index=4,direction='out'),set([0]))
-
+        self.assertEqual(net.neighbors_out(2, 3),set([1,2]))
 
         with self.assertRaises(ValueError):
-            self.assertEqual(net.neighbors(3,index=5,direction='out'))
+            self.assertEqual(net.neighbors_out(index=5, size=3))
 
         with self.assertRaises(TypeError):
-            self.assertEqual(net.neighbors(3,index='2',direction='out'))
+            self.assertEqual(net.neighbors_out(index='2', size=3))
 
         with self.assertRaises(ValueError):
-            self.assertEqual(net.neighbors(3,index=-1,direction='out'))
+            self.assertEqual(net.neighbors_out(size=3,index=-1))
 
         with self.assertRaises(ValueError):
-            self.assertEqual(net.neighbors(0,index=1,direction='out'))
+            self.assertEqual(net.neighbors_out(size=0,index=1))
 
 
     def test_neighbors_both(self):
 
         net = ca.ECA(30)
 
-        self.assertEqual(net.neighbors(4,direction='both'),[set([0, 1, 3]), 
-                                                         set([0,1,2]), 
-                                                         set([1,2,3]), 
-                                                         set([0,2,3])])
-
-        self.assertEqual(net.neighbors(4,index=2,direction='both'),set([1,2,3]))
-
-        net.boundary = (1,1)
-
-        self.assertEqual(net.neighbors(3,index=4,direction='both'),set([0]))
-
-
+        self.assertEqual(net.neighbors(2, 4),set([1,2,3]))
 

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -96,7 +96,7 @@ class TestCore(unittest.TestCase):
         self.assertTrue(neighbors(eca, 1, size=4), set([0, 1, 2]))
 
         with self.assertRaises(AttributeError):
-            neighbors(eca)
+            neighbors(eca, 1)
 
     def test_neighbors_WTNetwork(self):
         net = bnet.WTNetwork([[1]])
@@ -114,8 +114,8 @@ class TestCore(unittest.TestCase):
         # with self.assertRaises(AttributeError):
         #     neighbors(net)
 
-    def test_neighbors_IsNotNetwork(self):
-        net = self.IsNotNetwork()
-
-        with self.assertRaises(AttributeError):
-            neighbors(net)
+    # def test_neighbors_IsNotNetwork(self):
+    #     net = self.IsNotNetwork()
+    #
+    #     with self.assertRaises(AttributeError):
+    #         neighbors(net)

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -93,10 +93,7 @@ class TestCore(unittest.TestCase):
     def test_neighbors_ECA(self):
         eca = ca.ECA(30)
 
-        self.assertTrue(neighbors(eca,size=4),[set([0, 1, 3]), 
-                                               set([0, 1, 2]), 
-                                               set([1, 2, 3]), 
-                                               set([0, 2, 3])])
+        self.assertTrue(neighbors(eca, 1, size=4), set([0, 1, 2]))
 
         with self.assertRaises(AttributeError):
             neighbors(eca)
@@ -104,12 +101,12 @@ class TestCore(unittest.TestCase):
     def test_neighbors_WTNetwork(self):
         net = bnet.WTNetwork([[1]])
 
-        self.assertTrue(neighbors(net),[set([0])])
+        self.assertTrue(neighbors(net, 0), [set([0])])
 
     def test_neighbors_LogicNetwork(self):
         net = bnet.LogicNetwork([((0,), {'0'})])
 
-        self.assertTrue(neighbors(net),[set([0])])
+        self.assertTrue(neighbors(net, 0), [set([0])])
 
     def test_neighbors_IsNetwork(self):
         net = self.IsNetwork()
@@ -122,6 +119,3 @@ class TestCore(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             neighbors(net)
-
-
-

--- a/test/test_logic.py
+++ b/test/test_logic.py
@@ -99,7 +99,6 @@ class TestLogicNetwork(unittest.TestCase):
                                         ((1, 2, 0), set(
                                             ['010', '011', '101'])),
                                         ((3,), set(['1']))])
-        simple.neighbors()
 
     def test_logic_simple_read_no_commas(self):
         from os.path import dirname, abspath, realpath, join
@@ -185,19 +184,13 @@ class TestLogicNetwork(unittest.TestCase):
                             ((0, 1, 2), set(['010', '011', '101'])),
                             ((3,), set(['1']))])
 
-        self.assertEqual(net.neighbors(
-            index=2, direction='in'), set([0, 1, 2]))
-
-        self.assertEqual(net.neighbors(direction='in'), [set([1, 2]),
-                                                         set([0]),
-                                                         set([0, 1, 2]),
-                                                         set([3])])
+        self.assertEqual(net.neighbors_in(2), set([0, 1, 2]))
 
         with self.assertRaises(TypeError):
-            self.assertEqual(net.neighbors(index=2.0, direction='in'))
+            net.neighbors_in(2.0)
 
         with self.assertRaises(TypeError):
-            self.assertEqual(net.neighbors(index='2', direction='in'))
+            net.neighbors_in('2')
 
     def test_neighbors_out(self):
 
@@ -206,12 +199,7 @@ class TestLogicNetwork(unittest.TestCase):
                             ((0, 1, 2), set(['010', '011', '101'])),
                             ((3,), set(['1']))])
 
-        self.assertEqual(net.neighbors(index=2, direction='out'), set([0, 2]))
-
-        self.assertEqual(net.neighbors(direction='out'), [set([1, 2]),
-                                                          set([0, 2]),
-                                                          set([0, 2]),
-                                                          set([3])])
+        self.assertEqual(net.neighbors_out(2), set([0, 2]))
 
     def test_neighbors_both(self):
 
@@ -220,13 +208,7 @@ class TestLogicNetwork(unittest.TestCase):
                             ((0, 1, 2), set(['010', '011', '101'])),
                             ((3,), set(['1']))])
 
-        self.assertEqual(net.neighbors(direction='both'), [set([1, 2]),
-                                                           set([0, 2]),
-                                                           set([0, 1, 2]),
-                                                           set([3])])
-
-        self.assertEqual(net.neighbors(
-            index=2, direction='both'), set([0, 1, 2]))
+        self.assertEqual(net.neighbors(2), set([0, 1, 2]))
 
     def test_node_dependency(self):
         net = LogicNetwork([((1, 2), {'11', '10'}),


### PR DESCRIPTION
Removed the ability to return the neighborhood of all nodes. Promoted functions that return incoming neighbors and that return outgoing neighbors to public. These functions may be called frequently, so direct calling is preferable. They are also renamed to `neighbors_in` and `neighbors_out` respectably to make them consistent and more easily discovered through "tab" completion by user.

The ability to sort out `"in"`, `"out"` and `"both"` directions in the original class methods `neighbors` has been moved to the universal function `neighbors` in the `interface` module for less demanding usage.