### PR TITLE
Fix an algorithmic mistake in `random_binary_conditions`

### DIFF
--- a/neet/boolean/conv.py
+++ b/neet/boolean/conv.py
@@ -27,4 +27,4 @@ def wt_to_logic(net):
 
         truth_table.append((indices, conditions))
 
-    return LogicNetwork(truth_table, reduced=True)
+    return LogicNetwork(truth_table, net.names, reduced=True)

--- a/neet/boolean/randomnet.py
+++ b/neet/boolean/randomnet.py
@@ -63,7 +63,7 @@ def random_binary_states(n, p):
     Return a set of binary states. Each state has length `n` and the probability
     to appear in the set is `p`.
     """
-    integer, decimal = divmod(n * p, 1)
+    integer, decimal = divmod(2**n * p, 1)
     num_states = int(integer + np.random.choice(2, p=[1 - decimal, decimal]))
     state_idxs = np.random.choice(2 ** n, num_states, replace=False)
 

--- a/test/test_randomnet.py
+++ b/test/test_randomnet.py
@@ -20,8 +20,8 @@ class TestRandomnet(unittest.TestCase):
             random_logic(net, p=np.ones(net.size + 1))
 
     def test_random_binary_states(self):
-        self.assertEqual(2, len(random_binary_states(4, 0.5)))
-        self.assertTrue(len(random_binary_states(5, 0.5)) in (2, 3))
+        self.assertEqual(8, len(random_binary_states(4, 0.5)))
+        self.assertTrue(len(random_binary_states(3, 0.4)) in (3, 4))
 
     def test_random_logic_fixed_structure(self):
         net = mouse_cortical_7B


### PR DESCRIPTION
The number of states to pick should have been `2**n * p`, where `n` is the width of each binary condition and `p` is the bias. Before this change, it was implemented as `n * p`.