### PR TITLE
Bug Fix #104

### DIFF
--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -109,13 +109,13 @@ class LogicNetwork(object):
             # Encode the mask.
             mask_code = long(0)
             for idx in indices:
-                mask_code += 2 ** idx  # Low order, low index.
+                mask_code += 2 ** long(idx)  # Low order, low index.
             # Encode each condition of truth table.
             encoded_sub_table = set()
             for condition in conditions:
                 encoded_condition = long(0)
                 for idx, state in zip(indices, condition):
-                    encoded_condition += 2 ** idx if long(state) else 0
+                    encoded_condition += 2 ** long(idx) if int(state) else 0
                 encoded_sub_table.add(encoded_condition)
             self._encoded_table.append((mask_code, encoded_sub_table))
 

--- a/test/test_logic.py
+++ b/test/test_logic.py
@@ -2,7 +2,8 @@
 # Use of this source code is governed by a MIT
 # license that can be found in the LICENSE file.
 """Unit test for LogicNetwork"""
-import unittest
+import unittest, numpy as np
+from neet.python3 import *
 from neet.boolean import LogicNetwork
 from neet.exceptions import FormatError
 
@@ -26,6 +27,16 @@ class TestLogicNetwork(unittest.TestCase):
         self.assertEqual(2, net.size)
         self.assertEqual(['A', 'B'], net.names)
         self.assertEqual([(2, {0, 2}), (1, {1})], net._encoded_table)
+
+    def test_init_long(self):
+        table = [((), set()) for _ in range(65)]
+        table[0] = ((np.int64(64),), set('1'))
+
+        mask = long(2)**64
+
+        net = LogicNetwork(table)
+        self.assertEqual(net.table, table)
+        self.assertEqual(net._encoded_table[0], (mask, set([mask])))
 
     def test_inplace_update(self):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])


### PR DESCRIPTION
For large networks, greater than 64 nodes, the state encodings needed for the `LogicNetwork._encoded_network` overflow when a fixed size integer type, e.g. `np.int64` is provided as an index.

This is resolved by explicitly converting the indicies to arbitrary precision integer types.