### PR TITLE
Improve sensitivity performance

### DIFF
--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -247,7 +247,7 @@ class LogicNetwork(object):
             >>> net._unsafe_update([0, 0, 1], pin=[1], values={0: 0})
             [0, 0, 0]
         """
-        encoded_state = self.state_space().encode(net_state)
+        encoded_state = self.state_space()._unsafe_encode(net_state)
 
         if index is None:
             indices = range(self.size)

--- a/neet/sensitivity.py
+++ b/neet/sensitivity.py
@@ -49,7 +49,7 @@ def sensitivity(net, state, transitions=None):
         if transitions is not None:
             newState = transitions[_fast_encode(neighbor)]
         else:
-            newState = net.update(neighbor)
+            newState = net._unsafe_update(neighbor)
         s += _boolean_distance(newState, nextState)
 
     return s / net.size
@@ -75,7 +75,7 @@ def difference_matrix(net, state, transitions=None):
         if transitions is not None:
             newState = transitions[_fast_encode(neighbor)]
         else:
-            newState = net.update(neighbor)
+            newState = net._unsafe_update(neighbor)
         Q[:,j] = [ ( nextState[i] + newState[i] )%2 for i in range(N) ]
         
     return Q
@@ -156,10 +156,10 @@ def average_difference_matrix(net,states=None,weights=None,calc_trans=True):
                     # start with two states, one with j on and one with j off
                     jOff = copy.copy(state)
                     jOff[j] = 0
-                    jOffNext = net.update(jOff)[i]
+                    jOffNext = net._unsafe_update(jOff)[i]
                     jOn = copy.copy(state)
                     jOn[j] = 1
-                    jOnNext = net.update(jOn)[i]
+                    jOnNext = net._unsafe_update(jOn)[i]
                     # are the results different?
                     Q[i,j] += (jOffNext + jOnNext)%2
                 Q[i,j] /= float(len(otherNodeStates))


### PR DESCRIPTION
After a short profiling session, we noticed that the sensitivity function was (ultimately) calling the `StateSpace.__contains__` method significantly more often than expected. We realized that we were using `LogicNetwork.update` in tight loops where we could have been using `LogicNetwork._unsafe_update`. A bit more digging uncovered that the `LogicNetwork._unsafe_update` function was using `StateSpace.encode` when it could have used `StateSpace._unsafe_encode`.

After making these minor changes we gain a ~2.5x runtime improvement. We employed the new version to compute the sensitivity for all 69 biological networks in the GRN Survey: the result was a reduction in runtime from 392 seconds to 153 seconds.