### PR TITLE
Propogate pinning through landscape class

### DIFF
--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -10,9 +10,9 @@ from neet.statespace import StateSpace
 class WTNetwork(object):
     """
     The WTNetwork class represents weight/threshold-based boolean networks. As
-    such it is specified in terms of a matrix of edge weights and a vector of
-    node thresholds, and each node of the network is expected to be in either
-    of two states ``0`` or ``1``.
+    such it is specified in terms of a matrix of edge weights (rows are target
+    nodes) and a vector of node thresholds, and each node of the network is 
+    expected to be in either of two states ``0`` or ``1``.
     """
 
     def __init__(self, weights, thresholds=None, names=None, theta=None):
@@ -55,7 +55,7 @@ class WTNetwork(object):
             >>> net.thresholds
             array([ 0.,  0.,  0.])
 
-        :param weights: the network weights
+        :param weights: the network weights, where: source/column -> target/row
         :param thresholds: the network thresholds
         :param names: the names of the network nodes (optional)
         :parma theta: the threshold function to use

--- a/neet/statespace.py
+++ b/neet/statespace.py
@@ -178,7 +178,9 @@ class StateSpace(object):
     def _unsafe_encode(self, state):
         """
         Encode a state as an integer consistent with the state space, without
-        checking the validity of the arguments.
+        checking the validity of the arguments. The encoding is such that,
+        for example, the state [1, 0, 0] will correspond to 1; the state 
+        [1, 1, 0] will correspond to 3. 
 
         .. rubric:: Examples:
 
@@ -218,7 +220,9 @@ class StateSpace(object):
 
     def encode(self, state):
         """
-        Encode a state as an integer consistent with the state space.
+        Encode a state as an integer consistent with the state space. The encoding is such that,
+        for example, the state [1, 0, 0] will correspond to 1; the state [1, 1, 0] will 
+        correspond to 3. 
 
         .. rubric:: Examples:
 

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -393,7 +393,7 @@ class Landscape(StateSpace):
     together with information about state transitions and the topology of
     the state transition graph.
     """
-    def __init__(self, net, size=None):
+    def __init__(self, net, size=None, index=None, pin=None, values=None):
         """
         Construct the landscape for a network.
 
@@ -411,6 +411,9 @@ class Landscape(StateSpace):
 
         :param net: the network
         :param size: the size of the network (``None`` if fixed sized)
+        :param index: the index to update (or None)
+        :param pin: the indices to pin during update (or None)
+        :param values: a dictionary of index-value pairs to set after update
         :raises TypeError: if ``net`` is not a network
         :raises ValueError: if ``net`` is fixed sized and ``size`` is not ``None``
         :raises ValueError: if ``net`` is not fixed sized and ``size`` is ``None``
@@ -433,6 +436,9 @@ class Landscape(StateSpace):
             super(Landscape, self).__init__(state_space.bases)
 
         self.__net = net
+        self.__index = index
+        self.__pin = pin
+        self.__values = values
 
         self.__expounded = False
         self.__graph = None
@@ -695,7 +701,10 @@ class Landscape(StateSpace):
 
         transitions = np.empty(self.volume, dtype=np.int)
         for i, state in enumerate(self):
-            transitions[i] = encode(update(state))
+            transitions[i] = encode(update(state, 
+                                           index=self.__index, 
+                                           pin=self.__pin, 
+                                           values=self.__values))
 
         self.__transitions = transitions
 

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -607,7 +607,6 @@ class TestLandscape(unittest.TestCase):
         self.assertEqual([0, 515, 7, 517, 14, 525, 11, 521, 28, 543], list(trans[:10]))
         self.assertEqual([18, 16, 13, 14, 10, 8, 7, 4, 2, 0], list(trans[-10:]))
 
-############## NEW ECA transition tests ####################
     def test_transitions_eca_index(self):
         ca = ECA(30)
         l = Landscape(ca, size=3, index=1)
@@ -618,7 +617,7 @@ class TestLandscape(unittest.TestCase):
         l = Landscape(ca, size=3, index=0)
         self.assertEqual(ca, l.network)
         self.assertEqual(3, l.size)
-        self.assertEqual([0, 5, 6, 7, 4, 1, 2, 3], list(l.transitions))
+        self.assertEqual([0, 1, 3, 3, 5, 4, 6, 6], list(l.transitions))
 
         l = Landscape(ca, size=3, index=None)
         self.assertEqual(ca, l.network)
@@ -627,21 +626,21 @@ class TestLandscape(unittest.TestCase):
 
         # Regular unencoded transition, rule 30
         #      0          1          2          3          4          5          6          7
-        # [[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1], [1, 0, 0], [1, 0, 1], [1, 1, 0], [1, 1, 1]]
+        # [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]]
         # [[0, 0, 0], [1, 1, 1], [1, 1, 1], [1, 0, 0], [1, 1, 1], [0, 0, 1], [0, 1, 0], [0, 0, 0]]
         #      0          7          7          1          7          4          2          0
 
     def test_transitions_eca_pin(self):
         ca = ECA(30)
-        l = Landscape(ca, size=3, pin=1)
+        l = Landscape(ca, size=3, pin=[1])
         self.assertEqual(ca, l.network)
         self.assertEqual(3, l.size)
-        self.assertEqual([0, 5, 7, 6, 5, 1, 2, 2], list(l.transitions))
+        self.assertEqual([0, 5, 7, 3, 5, 4, 2, 2], list(l.transitions))
 
-        l = Landscape(ca, size=3, pin=0)
+        l = Landscape(ca, size=3, pin=[0])
         self.assertEqual(ca, l.network)
         self.assertEqual(3, l.size)
-        self.assertEqual([0, 3, 3, 0, 7, 1, 6, 4], list(l.transitions))
+        self.assertEqual([0, 7, 6, 1, 6, 5, 2, 1], list(l.transitions))
 
         l = Landscape(ca, size=3, pin=None)
         self.assertEqual(ca, l.network)
@@ -653,19 +652,20 @@ class TestLandscape(unittest.TestCase):
         l = Landscape(ca, size=3, values={0: 1})
         self.assertEqual(ca, l.network)
         self.assertEqual(3, l.size)
-        self.assertEqual([4, 7, 7, 4, 7, 5, 6, 3], list(l.transitions))
+        self.assertEqual([1, 7, 7, 1, 7, 5, 3, 1], list(l.transitions))
 
         l = Landscape(ca, size=3, values={1: 0})
         self.assertEqual(ca, l.network)
         self.assertEqual(3, l.size)
-        self.assertEqual([0, 5, 5, 4, 5, 1, 0, 0], list(l.transitions))
+        self.assertEqual([0, 5, 5, 1, 5, 4, 0, 0], list(l.transitions))
 
         l = Landscape(ca, size=3, values={})
         self.assertEqual(ca, l.network)
         self.assertEqual(3, l.size)
         self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(l.transitions))
 
-        ########################################
+########################################
+#######NEED TO ADD TESTS FOR LOGICNET AND WTNETWORK LANDSCAPES WITH PINNING ARGS. ###############
 
     def test_transitions_wtnetwork(self):
         net = WTNetwork(
@@ -678,6 +678,146 @@ class TestLandscape(unittest.TestCase):
         self.assertEqual(net, l.network)
         self.assertEqual(2, l.size);
         self.assertEqual([2,1,2,3], list(l.transitions))
+
+    def test_update_index(self):
+        net = bnet.WTNetwork([[1,0],[-1,1]], [0.5,0.0])
+
+        self.assertEqual(bnet.WTNetwork.split_threshold, net.theta)
+
+        xs = [0,0]
+        self.assertEqual([0,0], net.update(xs, 0))
+        self.assertEqual([0,0], net.update(xs, 1))
+        self.assertEqual([0,0], xs)
+
+        xs = [1,0]
+        self.assertEqual([1,0], net.update(xs, 0))
+        self.assertEqual([1,0], net.update(xs, 1))
+        self.assertEqual([1,0], xs)
+
+        xs = [0,1]
+        self.assertEqual([0,1], net.update(xs, 0))
+        self.assertEqual([0,1], net.update(xs, 1))
+        self.assertEqual([0,1], xs)
+
+        xs = [1,1]
+        self.assertEqual([1,1], net.update(xs, 0))
+        self.assertEqual([1,1], net.update(xs, 1))
+        self.assertEqual([1,1], xs)
+
+        net.theta = bnet.WTNetwork.negative_threshold
+
+        xs = [0,0]
+        self.assertEqual([0,0], net.update(xs, 0))
+        self.assertEqual([0,0], net.update(xs, 1))
+        self.assertEqual([0,0], xs)
+
+        xs = [1,0]
+        self.assertEqual([1,0], net.update(xs, 0))
+        self.assertEqual([1,0], net.update(xs, 1))
+        self.assertEqual([1,0], xs)
+
+        xs = [0,1]
+        self.assertEqual([0,1], net.update(xs, 0))
+        self.assertEqual([0,1], net.update(xs, 1))
+        self.assertEqual([0,1], xs)
+
+        xs = [1,1]
+        self.assertEqual([1,1], net.update(xs, 0))
+        self.assertEqual([1,0], net.update(xs, 1))
+        self.assertEqual([1,0], xs)
+
+        net.theta = bnet.WTNetwork.positive_threshold
+
+        xs = [0,0]
+        self.assertEqual([0,0], net.update(xs, 0))
+        self.assertEqual([0,1], net.update(xs, 1))
+        self.assertEqual([0,1], xs)
+
+        xs = [1,0]
+        self.assertEqual([1,0], net.update(xs, 0))
+        self.assertEqual([1,0], net.update(xs, 1))
+        self.assertEqual([1,0], xs)
+
+        xs = [0,1]
+        self.assertEqual([0,1], net.update(xs, 0))
+        self.assertEqual([0,1], net.update(xs, 1))
+        self.assertEqual([0,1], xs)
+
+        xs = [1,1]
+        self.assertEqual([1,1], net.update(xs, 0))
+        self.assertEqual([1,1], net.update(xs, 1))
+        self.assertEqual([1,1], xs)
+
+
+    def test_user_defined_threshold(self):
+        def reverse_negative(values, states):
+            if isinstance(values, list) or isinstance(values, np.ndarray):
+                for i, x in enumerate(values):
+                    if x <= 0:
+                        states[i] = 1
+                    else:
+                        states[i] = 0
+                return states
+            else:
+                if values <= 0:
+                    return 1
+                else:
+                    return 0
+
+        net = bnet.WTNetwork([[1,0],[-1,1]], [0.5,0.0], theta=reverse_negative)
+        xs = [0,0]
+        self.assertEqual([1,1], net.update(xs))
+        self.assertEqual([1,1], xs)
+
+        xs = [0,0]
+        self.assertEqual([1,0], net.update(xs, 0))
+        self.assertEqual([1,0], xs)
+
+        xs = [0,0]
+        self.assertEqual([0,1], net.update(xs, 1))
+        self.assertEqual([0,1], xs)
+
+        xs = [1,0]
+        self.assertEqual([0,1], net.update(xs))
+        self.assertEqual([0,1], xs)
+
+        xs = [1,0]
+        self.assertEqual([0,0], net.update(xs, 0))
+        self.assertEqual([0,0], xs)
+
+        xs = [1,0]
+        self.assertEqual([1,1], net.update(xs, 1))
+        self.assertEqual([1,1], xs)
+
+        xs = [0,1]
+        self.assertEqual([1,0], net.update(xs))
+        self.assertEqual([1,0], xs)
+
+        xs = [0,1]
+        self.assertEqual([1,1], net.update(xs, 0))
+        self.assertEqual([1,1], xs)
+
+        xs = [0,1]
+        self.assertEqual([0,0], net.update(xs, 1))
+        self.assertEqual([0,0], xs)
+
+        xs = [1,1]
+        self.assertEqual([0,1], net.update(xs))
+        self.assertEqual([0,1], xs)
+
+        xs = [1,1]
+        self.assertEqual([0,1], net.update(xs, 0))
+        self.assertEqual([0,1], xs)
+
+        xs = [1,1]
+        self.assertEqual([1,1], net.update(xs, 1))
+        self.assertEqual([1,1], xs)
+
+
+
+
+
+#########################################
 
     def test_transitions_logicnetwork(self):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -744,9 +744,6 @@ class TestLandscape(unittest.TestCase):
 
         ## Add more test for different thetas?
 
-########################################
-#######NEED TO ADD TESTS FOR LOGICNET AND WTNETWORK LANDSCAPES WITH PINNING ARGS. ###############
-
     def test_transitions_logicnetwork(self):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
 
@@ -810,8 +807,6 @@ class TestLandscape(unittest.TestCase):
         self.assertEqual([1,3,1,3], list(l.transitions))
 
         ## Add more test for different thetas?
-
-#########################################
 
     def test_transitions_spombe(self):
         l = Landscape(s_pombe)

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -607,6 +607,66 @@ class TestLandscape(unittest.TestCase):
         self.assertEqual([0, 515, 7, 517, 14, 525, 11, 521, 28, 543], list(trans[:10]))
         self.assertEqual([18, 16, 13, 14, 10, 8, 7, 4, 2, 0], list(trans[-10:]))
 
+############## NEW ECA transition tests ####################
+    def test_transitions_eca_index(self):
+        ca = ECA(30)
+        l = Landscape(ca, size=3, index=1)
+        self.assertEqual(ca, l.network)
+        self.assertEqual(3, l.size)
+        self.assertEqual([0, 3, 2, 1, 6, 5, 6, 5], list(l.transitions))
+
+        l = Landscape(ca, size=3, index=0)
+        self.assertEqual(ca, l.network)
+        self.assertEqual(3, l.size)
+        self.assertEqual([0, 5, 6, 7, 4, 1, 2, 3], list(l.transitions))
+
+        l = Landscape(ca, size=3, index=None)
+        self.assertEqual(ca, l.network)
+        self.assertEqual(3, l.size)
+        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(l.transitions))
+
+        # Regular unencoded transition, rule 30
+        #      0          1          2          3          4          5          6          7
+        # [[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1], [1, 0, 0], [1, 0, 1], [1, 1, 0], [1, 1, 1]]
+        # [[0, 0, 0], [1, 1, 1], [1, 1, 1], [1, 0, 0], [1, 1, 1], [0, 0, 1], [0, 1, 0], [0, 0, 0]]
+        #      0          7          7          1          7          4          2          0
+
+    def test_transitions_eca_pin(self):
+        ca = ECA(30)
+        l = Landscape(ca, size=3, pin=1)
+        self.assertEqual(ca, l.network)
+        self.assertEqual(3, l.size)
+        self.assertEqual([0, 5, 7, 6, 5, 1, 2, 2], list(l.transitions))
+
+        l = Landscape(ca, size=3, pin=0)
+        self.assertEqual(ca, l.network)
+        self.assertEqual(3, l.size)
+        self.assertEqual([0, 3, 3, 0, 7, 1, 6, 4], list(l.transitions))
+
+        l = Landscape(ca, size=3, pin=None)
+        self.assertEqual(ca, l.network)
+        self.assertEqual(3, l.size)
+        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(l.transitions))
+
+    def test_transitions_eca_values(self):
+        ca = ECA(30)
+        l = Landscape(ca, size=3, values={0: 1})
+        self.assertEqual(ca, l.network)
+        self.assertEqual(3, l.size)
+        self.assertEqual([4, 7, 7, 4, 7, 5, 6, 3], list(l.transitions))
+
+        l = Landscape(ca, size=3, values={1: 0})
+        self.assertEqual(ca, l.network)
+        self.assertEqual(3, l.size)
+        self.assertEqual([0, 5, 5, 4, 5, 1, 0, 0], list(l.transitions))
+
+        l = Landscape(ca, size=3, values={})
+        self.assertEqual(ca, l.network)
+        self.assertEqual(3, l.size)
+        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(l.transitions))
+
+        ########################################
+
     def test_transitions_wtnetwork(self):
         net = WTNetwork(
             weights=[[1, 0], [-1, 1]],

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -664,9 +664,6 @@ class TestLandscape(unittest.TestCase):
         self.assertEqual(3, l.size)
         self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(l.transitions))
 
-########################################
-#######NEED TO ADD TESTS FOR LOGICNET AND WTNETWORK LANDSCAPES WITH PINNING ARGS. ###############
-
     def test_transitions_wtnetwork(self):
         net = WTNetwork(
             weights=[[1, 0], [-1, 1]],
@@ -679,145 +676,76 @@ class TestLandscape(unittest.TestCase):
         self.assertEqual(2, l.size);
         self.assertEqual([2,1,2,3], list(l.transitions))
 
-    def test_update_index(self):
-        net = bnet.WTNetwork([[1,0],[-1,1]], [0.5,0.0])
+    def test_transitions_wtnetwork_index(self):
+        net = WTNetwork(
+            weights=[[1, 0], [-1, 1]],
+            thresholds=[0.5, 0.0],
+            theta=WTNetwork.positive_threshold
+        )
 
-        self.assertEqual(bnet.WTNetwork.split_threshold, net.theta)
+        l = Landscape(net, index=1)
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size);
+        self.assertEqual([2,1,2,3], list(l.transitions))
 
-        xs = [0,0]
-        self.assertEqual([0,0], net.update(xs, 0))
-        self.assertEqual([0,0], net.update(xs, 1))
-        self.assertEqual([0,0], xs)
+        l = Landscape(net, index=0)
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size);
+        self.assertEqual([0,1,2,3], list(l.transitions))
 
-        xs = [1,0]
-        self.assertEqual([1,0], net.update(xs, 0))
-        self.assertEqual([1,0], net.update(xs, 1))
-        self.assertEqual([1,0], xs)
+        l = Landscape(net, index=None)
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size);
+        self.assertEqual([2,1,2,3], list(l.transitions))
 
-        xs = [0,1]
-        self.assertEqual([0,1], net.update(xs, 0))
-        self.assertEqual([0,1], net.update(xs, 1))
-        self.assertEqual([0,1], xs)
+    def test_transitions_wtnetwork_pin(self):
+        net = WTNetwork(
+            weights=[[1, 0], [-1, 1]],
+            thresholds=[0.5, 0.0],
+            theta=WTNetwork.positive_threshold
+        )
 
-        xs = [1,1]
-        self.assertEqual([1,1], net.update(xs, 0))
-        self.assertEqual([1,1], net.update(xs, 1))
-        self.assertEqual([1,1], xs)
+        l = Landscape(net, pin=[1])
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size);
+        self.assertEqual([0,1,2,3], list(l.transitions))
 
-        net.theta = bnet.WTNetwork.negative_threshold
+        l = Landscape(net, pin=[0])
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size);
+        self.assertEqual([2,1,2,3], list(l.transitions))
 
-        xs = [0,0]
-        self.assertEqual([0,0], net.update(xs, 0))
-        self.assertEqual([0,0], net.update(xs, 1))
-        self.assertEqual([0,0], xs)
+        l = Landscape(net, pin=None)
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size);
+        self.assertEqual([2,1,2,3], list(l.transitions))
 
-        xs = [1,0]
-        self.assertEqual([1,0], net.update(xs, 0))
-        self.assertEqual([1,0], net.update(xs, 1))
-        self.assertEqual([1,0], xs)
+    def test_transitions_wtnetwork_values(self):
+        net = WTNetwork(
+            weights=[[1, 0], [-1, 1]],
+            thresholds=[0.5, 0.0],
+            theta=WTNetwork.positive_threshold
+        )
 
-        xs = [0,1]
-        self.assertEqual([0,1], net.update(xs, 0))
-        self.assertEqual([0,1], net.update(xs, 1))
-        self.assertEqual([0,1], xs)
+        l = Landscape(net, values={0: 1})
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size);
+        self.assertEqual([3,1,3,3], list(l.transitions))
 
-        xs = [1,1]
-        self.assertEqual([1,1], net.update(xs, 0))
-        self.assertEqual([1,0], net.update(xs, 1))
-        self.assertEqual([1,0], xs)
+        l = Landscape(net, values={1: 0})
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size);
+        self.assertEqual([0,1,0,1], list(l.transitions))
 
-        net.theta = bnet.WTNetwork.positive_threshold
+        l = Landscape(net, values={})
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size);
+        self.assertEqual([2,1,2,3], list(l.transitions))
 
-        xs = [0,0]
-        self.assertEqual([0,0], net.update(xs, 0))
-        self.assertEqual([0,1], net.update(xs, 1))
-        self.assertEqual([0,1], xs)
+        ## Add more test for different thetas?
 
-        xs = [1,0]
-        self.assertEqual([1,0], net.update(xs, 0))
-        self.assertEqual([1,0], net.update(xs, 1))
-        self.assertEqual([1,0], xs)
-
-        xs = [0,1]
-        self.assertEqual([0,1], net.update(xs, 0))
-        self.assertEqual([0,1], net.update(xs, 1))
-        self.assertEqual([0,1], xs)
-
-        xs = [1,1]
-        self.assertEqual([1,1], net.update(xs, 0))
-        self.assertEqual([1,1], net.update(xs, 1))
-        self.assertEqual([1,1], xs)
-
-
-    def test_user_defined_threshold(self):
-        def reverse_negative(values, states):
-            if isinstance(values, list) or isinstance(values, np.ndarray):
-                for i, x in enumerate(values):
-                    if x <= 0:
-                        states[i] = 1
-                    else:
-                        states[i] = 0
-                return states
-            else:
-                if values <= 0:
-                    return 1
-                else:
-                    return 0
-
-        net = bnet.WTNetwork([[1,0],[-1,1]], [0.5,0.0], theta=reverse_negative)
-        xs = [0,0]
-        self.assertEqual([1,1], net.update(xs))
-        self.assertEqual([1,1], xs)
-
-        xs = [0,0]
-        self.assertEqual([1,0], net.update(xs, 0))
-        self.assertEqual([1,0], xs)
-
-        xs = [0,0]
-        self.assertEqual([0,1], net.update(xs, 1))
-        self.assertEqual([0,1], xs)
-
-        xs = [1,0]
-        self.assertEqual([0,1], net.update(xs))
-        self.assertEqual([0,1], xs)
-
-        xs = [1,0]
-        self.assertEqual([0,0], net.update(xs, 0))
-        self.assertEqual([0,0], xs)
-
-        xs = [1,0]
-        self.assertEqual([1,1], net.update(xs, 1))
-        self.assertEqual([1,1], xs)
-
-        xs = [0,1]
-        self.assertEqual([1,0], net.update(xs))
-        self.assertEqual([1,0], xs)
-
-        xs = [0,1]
-        self.assertEqual([1,1], net.update(xs, 0))
-        self.assertEqual([1,1], xs)
-
-        xs = [0,1]
-        self.assertEqual([0,0], net.update(xs, 1))
-        self.assertEqual([0,0], xs)
-
-        xs = [1,1]
-        self.assertEqual([0,1], net.update(xs))
-        self.assertEqual([0,1], xs)
-
-        xs = [1,1]
-        self.assertEqual([0,1], net.update(xs, 0))
-        self.assertEqual([0,1], xs)
-
-        xs = [1,1]
-        self.assertEqual([1,1], net.update(xs, 1))
-        self.assertEqual([1,1], xs)
-
-
-
-
-
-#########################################
+########################################
+#######NEED TO ADD TESTS FOR LOGICNET AND WTNETWORK LANDSCAPES WITH PINNING ARGS. ###############
 
     def test_transitions_logicnetwork(self):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
@@ -826,6 +754,64 @@ class TestLandscape(unittest.TestCase):
         self.assertEqual(net, l.network)
         self.assertEqual(2, l.size)
         self.assertEqual([1, 3, 1, 3], list(l.transitions))
+
+    def test_transitions_logicnetwork_index(self):
+        net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
+
+        l = Landscape(net, index=1)
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([0,3,0,3], list(l.transitions))
+
+        l = Landscape(net, index=0)
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([1,1,3,3], list(l.transitions))
+
+        l = Landscape(net, index=None)
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([1,3,1,3], list(l.transitions))
+
+    def test_transitions_logicnetwork_pin(self):
+        net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
+
+        l = Landscape(net, pin=[1])
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([1,1,3,3], list(l.transitions))
+
+        l = Landscape(net, pin=[0])
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([0,3,0,3], list(l.transitions))
+
+        l = Landscape(net, pin=None)
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([1,3,1,3], list(l.transitions))
+
+    def test_transitions_logicnetwork_values(self):
+        net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
+
+        l = Landscape(net, values={0: 1})
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([1,3,1,3], list(l.transitions))
+
+        l = Landscape(net, values={1: 0})
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([1,1,1,1], list(l.transitions))
+
+        l = Landscape(net, values={})
+        self.assertEqual(net, l.network)
+        self.assertEqual(2, l.size)
+        self.assertEqual([1,3,1,3], list(l.transitions))
+
+        ## Add more test for different thetas?
+
+#########################################
 
     def test_transitions_spombe(self):
         l = Landscape(s_pombe)


### PR DESCRIPTION
Addresses #81, and also clarifies improves some method documentation in the classes: `WTNetwork` and `Statespace` (towards #70)