### PR TITLE
Introduce a hierarchy of state space classes

### DIFF
--- a/neet/boolean/eca.py
+++ b/neet/boolean/eca.py
@@ -9,7 +9,7 @@ with an arbitrary rule.
 .. rubric:: Examples
 """
 import numpy as np
-from neet.statespace import UniformSpace
+from neet.statespace import BooleanSpace
 from .network import BooleanNetwork
 
 
@@ -100,7 +100,7 @@ class ECA(BooleanNetwork):
         if size < 1:
             raise ValueError("ECA size is negative")
         self._size = size
-        self._state_space = UniformSpace(ndim=size, base=2)
+        self._state_space = BooleanSpace(size)
 
     @property
     def boundary(self):

--- a/neet/boolean/eca.py
+++ b/neet/boolean/eca.py
@@ -9,7 +9,7 @@ with an arbitrary rule.
 .. rubric:: Examples
 """
 import numpy as np
-from neet.statespace import StateSpace
+from neet.statespace import UniformSpace
 from .network import BooleanNetwork
 
 
@@ -100,7 +100,7 @@ class ECA(BooleanNetwork):
         if size < 1:
             raise ValueError("ECA size is negative")
         self._size = size
-        self._state_space = StateSpace(size)
+        self._state_space = UniformSpace(ndim=size, base=2)
 
     @property
     def boundary(self):

--- a/neet/boolean/network.py
+++ b/neet/boolean/network.py
@@ -11,13 +11,13 @@ API Documentation
 -----------------
 """
 from neet.network import Network
-from neet.statespace import StateSpace
+from neet.statespace import UniformSpace
 
 
 class BooleanNetwork(Network):
     def __init__(self, size, names=None, metadata=None):
         super(BooleanNetwork, self).__init__(size, names, metadata)
-        self._state_space = StateSpace(self.size, base=2)
+        self._state_space = UniformSpace(ndim=size, base=2)
 
     def state_space(self):
         return self._state_space

--- a/neet/boolean/network.py
+++ b/neet/boolean/network.py
@@ -11,13 +11,13 @@ API Documentation
 -----------------
 """
 from neet.network import Network
-from neet.statespace import UniformSpace
+from neet.statespace import BooleanSpace
 
 
 class BooleanNetwork(Network):
     def __init__(self, size, names=None, metadata=None):
         super(BooleanNetwork, self).__init__(size, names, metadata)
-        self._state_space = UniformSpace(ndim=size, base=2)
+        self._state_space = BooleanSpace(size)
 
     def state_space(self):
         return self._state_space

--- a/neet/network.py
+++ b/neet/network.py
@@ -83,7 +83,7 @@ class Network(object):
                 if k in pin:
                     raise ValueError("cannot set a value for a pinned state")
         if values is not None:
-            bases = [space.base for _ in range(space.ndim)] if space.is_uniform else space.base
+            bases = space.shape
             for key in values.keys():
                 val = values[key]
                 if val < 0 or val >= bases[key]:

--- a/neet/statespace.py
+++ b/neet/statespace.py
@@ -58,8 +58,6 @@ class StateSpace(object):
             return True
         except TypeError:
             return False
-        except IndexError:
-            return False
 
     def _unsafe_encode(self, state):
         encoded, place = long(0), long(1)
@@ -121,8 +119,6 @@ class UniformSpace(StateSpace):
             return True
         except TypeError:
             return False
-        except IndexError:
-            return False
 
     def _unsafe_encode(self, state):
         encoded, place = long(0), long(1)
@@ -172,8 +168,6 @@ class BooleanSpace(UniformSpace):
                     return False
             return True
         except TypeError:
-            return False
-        except IndexError:
             return False
 
     def _unsafe_encode(self, state):

--- a/neet/statespace.py
+++ b/neet/statespace.py
@@ -141,3 +141,52 @@ class UniformSpace(StateSpace):
             state[i] = encoded % base
             encoded = int(encoded / base)
         return state
+
+
+class BooleanSpace(UniformSpace):
+    def __init__(self, ndim):
+        super(BooleanSpace, self).__init__(ndim, base=2)
+
+    def __iter__(self):
+        ndim = self.ndim
+        state = [0] * ndim
+        yield state[:]
+        i = 0
+        while i != ndim:
+            if state[i] == 0:
+                state[i] += 1
+                for j in range(i):
+                    state[j] = 0
+                i = 0
+                yield state[:]
+            else:
+                i += 1
+
+    def __contains__(self, state):
+        try:
+            if len(state) != self.ndim:
+                return False
+
+            for x in state:
+                if x != 0 and x != 1:
+                    return False
+            return True
+        except TypeError:
+            return False
+        except IndexError:
+            return False
+
+    def _unsafe_encode(self, state):
+        encoded, place = long(0), long(1)
+        for x in state:
+            encoded += place * long(x)
+            place <<= 1
+        return encoded
+
+    def decode(self, encoded):
+        ndim = self.ndim
+        state = [0] * ndim
+        for i in range(ndim):
+            state[i] = encoded & 1
+            encoded >>= 1
+        return state

--- a/neet/statespace.py
+++ b/neet/statespace.py
@@ -80,17 +80,17 @@ class StateSpace(object):
             elif base < 1:
                 raise ValueError("base must be positive, nonzero")
 
-            self.__is_uniform = True
-            self.__ndim = spec
-            self.__base = base
-            self.__volume = base**spec
+            self._is_uniform = True
+            self._ndim = spec
+            self._base = base
+            self._volume = base**spec
 
         elif isinstance(spec, list):
             if len(spec) == 0:
                 raise ValueError("bases cannot be an empty")
             else:
-                self.__is_uniform = True
-                self.__volume = 1
+                self._is_uniform = True
+                self._volume = 1
                 first_base = spec[0]
                 if base is not None and first_base != base:
                     raise ValueError("base does not match base of spec")
@@ -100,16 +100,16 @@ class StateSpace(object):
                     elif spec_base < 1:
                         msg = "spec may only contain positive elements"
                         raise ValueError(msg)
-                    if self.__is_uniform and spec_base != first_base:
-                        self.__is_uniform = False
+                    if self._is_uniform and spec_base != first_base:
+                        self._is_uniform = False
                         if base is not None:
                             raise ValueError("b does not match base of spec")
-                    self.__volume *= spec_base
-                self.__ndim = len(spec)
-                if self.__is_uniform:
-                    self.__base = first_base
+                    self._volume *= spec_base
+                self._ndim = len(spec)
+                if self._is_uniform:
+                    self._base = first_base
                 else:
-                    self.__base = spec[:]
+                    self._base = spec[:]
         else:
             raise TypeError("spec must be an int or a list")
 
@@ -118,7 +118,7 @@ class StateSpace(object):
         """
         Get the dimensionality of the state space.
         """
-        return self.__ndim
+        return self._ndim
 
     @property
     def base(self):
@@ -130,21 +130,21 @@ class StateSpace(object):
 
         :return: a list of bases, one for each dimension
         """
-        return self.__base
+        return self._base
 
     @property
     def volume(self):
         """
         Get the volume of the state space.
         """
-        return self.__volume
+        return self._volume
 
     @property
     def is_uniform(self):
         """
         Get whether every direction in the state space has the same base.
         """
-        return self.__is_uniform
+        return self._is_uniform
 
     def __iter__(self):
         """
@@ -185,7 +185,7 @@ class StateSpace(object):
         yield state[:]
         i = 0
         while i != self.ndim:
-            base = self.__base if self.__is_uniform else self.__base[i]
+            base = self._base if self._is_uniform else self._base[i]
             if state[i] + 1 < base:
                 state[i] += 1
                 for j in range(i):
@@ -271,7 +271,7 @@ class StateSpace(object):
         """
         encoded, place = long(0), long(1)
 
-        base = self.__base
+        base = self._base
         if self.is_uniform:
             for x in state:
                 encoded += place * x
@@ -340,15 +340,15 @@ class StateSpace(object):
         :type encoded: int
         :returns: the decoded state as a list
         """
-        state = [0] * self.__ndim
-        base = self.__base
+        state = [0] * self._ndim
+        base = self._base
         if self.is_uniform:
             b = base
-            for i in range(self.__ndim):
+            for i in range(self._ndim):
                 state[i] = encoded % b
                 encoded = int(encoded / b)
         else:
-            for i in range(self.__ndim):
+            for i in range(self._ndim):
                 b = base[i]
                 state[i] = encoded % b
                 encoded = int(encoded / b)

--- a/neet/statespace.py
+++ b/neet/statespace.py
@@ -1,191 +1,43 @@
-"""
-.. currentmodule:: neet.statespace
-
-.. testsetup:: statespace
-
-    from neet.statespace import StateSpace
-
-State Space
-===========
-
-A fundamental property of networks is their state space. The
-:class:`StateSpace` class provides a type for representing such a state
-space. It has anumber of convenient properties, in particular
-
-1. it is iterable, :meth:`StateSpace.__iter__`
-2. you can ask if it contains a particular state,
-   :meth:`StateSpace.__contains__`
-3. it can :meth:`StateSpace.encode` states as integers, and
-   :meth:`StateSpace.decode` integers into states
-
-All of this together facilitates the clean implementation of many of the core
-functions of :mod:`neet`.
-
-API Documentation
------------------
-"""
 from .python import long
 
 
 class StateSpace(object):
-    """
-    :class:`StateSpace` represents the state space of a network model. It may be
-    either uniform, i.e. all nodes have the same base, or non-uniform.
-    """
-
-    def __init__(self, spec, base=None):
-        """
-        Initialize the state spec in accordance with the provided ``spec``
-        and base ``base``.
-
-        .. rubric:: Examples of Uniform State Spaces:
-
-        .. doctest:: statespace
-
-            >>> spec = StateSpace(5)
-            >>> (spec.is_uniform, spec.ndim, spec.base)
-            (True, 5, 2)
-            >>> spec = StateSpace(3, base=3)
-            >>> (spec.is_uniform, spec.ndim, spec.base)
-            (True, 3, 3)
-            >>> spec = StateSpace([2, 2, 2])
-            >>> (spec.is_uniform, spec.ndim, spec.base)
-            (True, 3, 2)
-
-        .. rubric:: Examples of Non-Uniform State Spaces:
-
-        .. doctest:: statespace
-
-            >>> spec = StateSpace([2, 3, 4])
-            >>> (spec.is_uniform, spec.base, spec.ndim)
-            (False, [2, 3, 4], 3)
-
-        :param spec: the number of nodes or an array of node bases
-        :type spec: int or list
-        :param base: the base of the network nodes (ignored if ``spec`` is
-                     a list)
-        :raises TypeError: if ``spec`` is neither an int nor a list of ints
-        :raises TypeError: if ``base`` is neither ``None`` nor an int
-        :raises ValueError: if ``base`` is negative or zero
-        :raises ValueError: if any element of ``spec`` is negative or zero
-        :raises ValueError: if ``spec`` is empty
-        """
-        if isinstance(spec, int):
-            if spec < 1:
-                raise ValueError("ndim cannot be zero or negative")
-            if base is None:
-                base = 2
-            elif not isinstance(base, int):
-                raise TypeError("base must be an int")
-            elif base < 1:
-                raise ValueError("base must be positive, nonzero")
-
-            self._is_uniform = True
-            self._ndim = spec
-            self._base = base
-            self._volume = base**spec
-
-        elif isinstance(spec, list):
-            if len(spec) == 0:
-                raise ValueError("bases cannot be an empty")
+    def __init__(self, shape):
+        if isinstance(shape, list):
+            if len(shape) == 0:
+                raise ValueError("shape cannot be empty")
             else:
-                self._is_uniform = True
                 self._volume = 1
-                first_base = spec[0]
-                if base is not None and first_base != base:
-                    raise ValueError("base does not match base of spec")
-                for spec_base in spec:
-                    if not isinstance(spec_base, int):
-                        raise TypeError("spec must be a list of ints")
-                    elif spec_base < 1:
-                        msg = "spec may only contain positive elements"
-                        raise ValueError(msg)
-                    if self._is_uniform and spec_base != first_base:
-                        self._is_uniform = False
-                        if base is not None:
-                            raise ValueError("b does not match base of spec")
-                    self._volume *= spec_base
-                self._ndim = len(spec)
-                if self._is_uniform:
-                    self._base = first_base
-                else:
-                    self._base = spec[:]
+                for base in shape:
+                    if not isinstance(base, int):
+                        raise TypeError("shape must be a list of ints")
+                    elif base < 1:
+                        raise ValueError("shape may only contain positive elements")
+                    self._volume *= base
+                self._ndim = len(shape)
+                self._shape = shape[:]
         else:
-            raise TypeError("spec must be an int or a list")
+            raise TypeError("shape must be a list")
 
     @property
     def ndim(self):
-        """
-        Get the dimensionality of the state space.
-        """
         return self._ndim
 
     @property
-    def base(self):
-        """
-        Get the base of each direction of the state space.
-
-        If the state space is not uniform, the result is a list of bases
-        (one for each dimension). Otherwise, the result is an integer.
-
-        :return: a list of bases, one for each dimension
-        """
-        return self._base
+    def shape(self):
+        return self._shape
 
     @property
     def volume(self):
-        """
-        Get the volume of the state space.
-        """
         return self._volume
 
-    @property
-    def is_uniform(self):
-        """
-        Get whether every direction in the state space has the same base.
-        """
-        return self._is_uniform
-
     def __iter__(self):
-        """
-        Iterate over the states in the state space
-
-        .. rubric:: Examples of Boolean Spaces
-
-        .. doctest:: statespace
-
-            >>> list(StateSpace(1))
-            [[0], [1]]
-            >>> list(StateSpace(2))
-            [[0, 0], [1, 0], [0, 1], [1, 1]]
-            >>> list(StateSpace(3))
-            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]]
-
-        .. rubric:: Examples of Non-Boolean Spaces
-
-        .. doctest:: statespace
-
-            >>> list(StateSpace(1, base=3))
-            [[0], [1], [2]]
-            >>> list(StateSpace(2, base=4))
-            [[0, 0], [1, 0], [2, 0], [3, 0], [0, 1], [1, 1], [2, 1], [3, 1], [0, 2], [1, 2], [2, 2], [3, 2], [0, 3], [1, 3], [2, 3], [3, 3]]
-
-        .. rubric:: Examples of Non-Uniform Spaces
-
-        .. doctest:: statespace
-
-            >>> list(StateSpace([1,2,3]))
-            [[0, 0, 0], [0, 1, 0], [0, 0, 1], [0, 1, 1], [0, 0, 2], [0, 1, 2]]
-            >>> list(StateSpace([3,4]))
-            [[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1], [0, 2], [1, 2], [2, 2], [0, 3], [1, 3], [2, 3]]
-
-        :yields: each possible state in the state space
-        """
-        state = [0] * self.ndim
+        ndim, shape = self.ndim, self.shape
+        state = [0] * ndim
         yield state[:]
         i = 0
-        while i != self.ndim:
-            base = self._base if self._is_uniform else self._base[i]
+        while i != ndim:
+            base = shape[i]
             if state[i] + 1 < base:
                 state[i] += 1
                 for j in range(i):
@@ -196,160 +48,96 @@ class StateSpace(object):
                 i += 1
 
     def __contains__(self, states):
-        """
-        Determine if a state is in the state space
-
-        .. rubric:: Examples:
-
-        .. doctest:: statespace
-
-            >>> state_space = StateSpace(3)
-            >>> [0, 0, 0] in state_space
-            True
-            >>> [0, 0] in state_space
-            False
-            >>> [1, 2, 1] in state_space
-            False
-
-        .. doctest:: statespace
-
-            >>> [0, 2, 1] in StateSpace([2, 3, 2])
-            True
-            >>> [0, 1] in StateSpace([2, 2, 3])
-            False
-            >>> [1, 1, 6] in StateSpace([2, 3, 4])
-            False
-
-        :param states: the one-dimensional sequence of node states
-        :returns: ``True`` if the ``states`` are valid
-        """
         try:
             if len(states) != self.ndim:
                 return False
 
-            if self.is_uniform:
-                for state in states:
-                    if state not in range(self.base):
-                        return False
-            else:
-                for state, base in zip(states, self.base):
-                    if state not in range(base):
-                        return False
+            for state, base in zip(states, self.shape):
+                if state < 0 or state >= base:
+                    return False
+            return True
         except TypeError:
             return False
         except IndexError:
             return False
 
-        return True
-
     def _unsafe_encode(self, state):
-        """
-        Encode a state as an integer consistent with the state space, without
-        checking the validity of the arguments. The encoding is such that,
-        for example, the state [1, 0, 0] will correspond to 1; the state
-        [1, 1, 0] will correspond to 3.
-
-        .. rubric:: Examples:
-
-        .. doctest:: statespace
-
-            >>> space = StateSpace(3, base=2)
-            >>> [space._unsafe_encode(s) for s in space]
-            [0, 1, 2, 3, 4, 5, 6, 7]
-
-        .. doctest:: statespace
-
-            >>> space = StateSpace([2,3,4])
-            >>> [space._unsafe_encode(s) for s in space]
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
-
-
-        :param state: the state to encode
-        :type state: list
-        :returns: a unique integer encoding of the state
-        :raises ValueError: if ``state`` has an incorrect length
-        """
         encoded, place = long(0), long(1)
 
-        base = self._base
-        if self.is_uniform:
-            for x in state:
-                encoded += place * x
-                place *= base
-        else:
-            for (x, b) in zip(state, base):
-                encoded += place * x
-                place *= b
+        for (x, b) in zip(state, self.shape):
+            encoded += place * x
+            place *= b
 
         return long(encoded)
 
     def encode(self, state):
-        """
-        Encode a state as an integer consistent with the state space. The
-        encoding is such that, for example, the state [1, 0, 0] will
-        correspond to 1; the state [1, 1, 0] will correspond to 3.
-
-        .. rubric:: Examples:
-
-        .. doctest:: statespace
-
-            >>> space = StateSpace(3, base=2)
-            >>> [space.encode(s) for s in space]
-            [0, 1, 2, 3, 4, 5, 6, 7]
-
-        .. doctest:: statespace
-
-            >>> space = StateSpace([2,3,4])
-            >>> [space.encode(s) for s in space]
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
-
-
-        :param state: the state to encode
-        :type state: list
-        :returns: a unique integer encoding of the state
-        :raises ValueError: if ``state`` has an incorrect length
-        """
         if state not in self:
             raise ValueError("state is not in state space")
 
         return self._unsafe_encode(state)
 
     def decode(self, encoded):
-        """
-        Decode an integer into a state in accordance with the state space.
+        ndim = self.ndim
+        state = [0] * ndim
+        for (i, base) in enumerate(self.shape):
+            state[i] = encoded % base
+            encoded = int(encoded / base)
+        return state
 
-        .. rubric:: Examples:
 
-        .. doctest:: statespace
+class UniformSpace(StateSpace):
+    def __init__(self, ndim, base):
+        super(UniformSpace, self).__init__([base] * ndim)
+        self._base = base
 
-            >>> space = StateSpace(3)
-            >>> list(space)
-            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]]
-            >>> [space.decode(x) for x in range(space.volume)]
-            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]]
+    @property
+    def base(self):
+        return self._base
 
-        .. doctest:: statespace
+    def __iter__(self):
+        ndim, base = self.ndim, self.base
+        state = [0] * ndim
+        yield state[:]
+        i = 0
+        while i != ndim:
+            if state[i] + 1 < base:
+                state[i] += 1
+                for j in range(i):
+                    state[j] = 0
+                i = 0
+                yield state[:]
+            else:
+                i += 1
 
-            >>> space = StateSpace([2,3])
-            >>> list(space)
-            [[0, 0], [1, 0], [0, 1], [1, 1], [0, 2], [1, 2]]
-            >>> [space.decode(x) for x in range(space.volume)]
-            [[0, 0], [1, 0], [0, 1], [1, 1], [0, 2], [1, 2]]
+    def __contains__(self, state):
+        try:
+            if len(state) != self.ndim:
+                return False
 
-        :param encoded: the encoded state
-        :type encoded: int
-        :returns: the decoded state as a list
-        """
-        state = [0] * self._ndim
-        base = self._base
-        if self.is_uniform:
-            b = base
-            for i in range(self._ndim):
-                state[i] = encoded % b
-                encoded = int(encoded / b)
-        else:
-            for i in range(self._ndim):
-                b = base[i]
-                state[i] = encoded % b
-                encoded = int(encoded / b)
+            base = self.base
+            for x in state:
+                if x < 0 or x >= base:
+                    return False
+            return True
+        except TypeError:
+            return False
+        except IndexError:
+            return False
+
+    def _unsafe_encode(self, state):
+        encoded, place = long(0), long(1)
+
+        base = self.base
+        for x in state:
+            encoded += place * long(x)
+            place *= base
+
+        return encoded
+
+    def decode(self, encoded):
+        ndim, base = self.ndim, self.base
+        state = [0] * ndim
+        for i in range(ndim):
+            state[i] = encoded % base
+            encoded = int(encoded / base)
         return state

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -396,10 +396,7 @@ class Landscape(StateSpace):
         else:
             state_space = net.state_space()
 
-        if state_space.is_uniform:
-            super(Landscape, self).__init__(state_space.ndim, state_space.base)
-        else:
-            super(Landscape, self).__init__(state_space.bases)
+        super(Landscape, self).__init__(state_space.shape)
 
         self.__net = net
         self.__index = index

--- a/test/test_statespace.py
+++ b/test/test_statespace.py
@@ -199,6 +199,9 @@ class TestStateSpace(unittest.TestCase):
         self.assertTrue([0, 0] not in state_space)
         self.assertTrue([1, 2, 0] not in state_space)
 
+        self.assertFalse(1 in state_space)
+        self.assertFalse("string" in state_space)
+
     def test_check_states_varied(self):
         self.assertTrue([0, 2, 1] in StateSpace([2, 3, 2]))
         self.assertFalse([0, 1] in StateSpace([2, 2, 3]))
@@ -207,6 +210,9 @@ class TestStateSpace(unittest.TestCase):
         self.assertFalse([0, 2, 1] not in StateSpace([2, 3, 2]))
         self.assertTrue([0, 1] not in StateSpace([2, 2, 3]))
         self.assertTrue([1, 1, 6] not in StateSpace([2, 3, 4]))
+
+        self.assertFalse(1 in StateSpace([2, 3, 2]))
+        self.assertFalse("string" in StateSpace([2, 3, 2]))
 
     def test_long_encoding(self):
         state_space = StateSpace([2] * 10)
@@ -367,6 +373,9 @@ class TestUniformSpace(unittest.TestCase):
         self.assertTrue([0, 0] not in state_space)
         self.assertTrue([1, 2, 0] not in state_space)
 
+        self.assertFalse(1 in state_space)
+        self.assertFalse("string" in state_space)
+
         state_space = UniformSpace(ndim=3, base=3)
         self.assertTrue([0, 1, 1] in state_space)
         self.assertFalse([0, 0] in state_space)
@@ -377,6 +386,9 @@ class TestUniformSpace(unittest.TestCase):
         self.assertTrue([0, 0] not in state_space)
         self.assertFalse([1, 2, 0] not in state_space)
         self.assertTrue([1, 2, 3] not in state_space)
+
+        self.assertFalse(1 in state_space)
+        self.assertFalse("string" in state_space)
 
     def test_long_encoding(self):
         state_space = UniformSpace(ndim=10, base=2)
@@ -493,6 +505,9 @@ class TestBooleanSpace(unittest.TestCase):
         self.assertFalse([0, 1, 1] not in state_space)
         self.assertTrue([0, 0] not in state_space)
         self.assertTrue([1, 2, 0] not in state_space)
+
+        self.assertFalse(1 in state_space)
+        self.assertFalse("string" in state_space)
 
     def test_long_encoding(self):
         state_space = BooleanSpace(10)

--- a/test/test_statespace.py
+++ b/test/test_statespace.py
@@ -1,34 +1,24 @@
 import unittest
 from neet.python import long
-from neet.statespace import StateSpace
+from neet.statespace import StateSpace, UniformSpace
 import numpy as np
 
 
 class TestStateSpace(unittest.TestCase):
-    def test_invalid_spec_type(self):
+    def test_invalid_shape_type(self):
+        with self.assertRaises(TypeError):
+            StateSpace(2)
+
         with self.assertRaises(TypeError):
             StateSpace("a")
 
         with self.assertRaises(TypeError):
             StateSpace("abc")
 
-    def test_invalid_base_type(self):
-        with self.assertRaises(TypeError):
-            StateSpace(5, base='a')
-
-        with self.assertRaises(TypeError):
-            StateSpace(3, base=2.5)
-
         with self.assertRaises(TypeError):
             StateSpace([1.0, 2.0, 3.0])
 
-    def test_invalid_spec_value(self):
-        with self.assertRaises(ValueError):
-            StateSpace(0)
-
-        with self.assertRaises(ValueError):
-            StateSpace(-1)
-
+    def test_invalid_shape_value(self):
         with self.assertRaises(ValueError):
             StateSpace([])
 
@@ -38,109 +28,51 @@ class TestStateSpace(unittest.TestCase):
         with self.assertRaises(ValueError):
             StateSpace([-1])
 
-    def test_invalid_base_value(self):
-        with self.assertRaises(ValueError):
-            StateSpace(3, base=0)
+    def test_uniform_shape(self):
+        space = StateSpace([2, 2, 2, 2, 2])
+        self.assertEqual(5, space.ndim)
+        self.assertEqual([2, 2, 2, 2, 2], space.shape)
+        self.assertEqual(32, space.volume)
 
-        with self.assertRaises(ValueError):
-            StateSpace(4, base=-1)
+        space = StateSpace([4, 4, 4, 4, 4, 4, 4, 4])
+        self.assertEqual(8, space.ndim)
+        self.assertEqual([4, 4, 4, 4, 4, 4, 4, 4], space.shape)
+        self.assertEqual(65536, space.volume)
 
-    def test_uniform_bases(self):
-        spec = StateSpace(5)
-        self.assertTrue(spec.is_uniform)
-        self.assertEqual(5, spec.ndim)
-        self.assertEqual(2, spec.base)
-        self.assertEqual(32, spec.volume)
+        space = StateSpace([3, 3, 3, 3])
+        self.assertEqual(4, space.ndim)
+        self.assertEqual([3, 3, 3, 3], space.shape)
+        self.assertEqual(81, space.volume)
 
-        spec = StateSpace(8, base=4)
-        self.assertTrue(spec.is_uniform)
-        self.assertEqual(8, spec.ndim)
-        self.assertEqual(4, spec.base)
-        self.assertEqual(65536, spec.volume)
-
-        spec = StateSpace([3, 3, 3, 3])
-        self.assertTrue(spec.is_uniform)
-        self.assertEqual(4, spec.ndim)
-        self.assertEqual(3, spec.base)
-        self.assertEqual(81, spec.volume)
-
-    def test_base_mismatch(self):
-        with self.assertRaises(ValueError):
-            StateSpace([2, 2, 2], base=3)
-
-        with self.assertRaises(ValueError):
-            StateSpace([3, 3, 3], base=2)
-
-        with self.assertRaises(ValueError):
-            StateSpace([2, 2, 3], base=2)
-
-        with self.assertRaises(ValueError):
-            StateSpace([2, 2, 3], base=3)
-
-        StateSpace([2, 2, 2], base=2)
-        StateSpace([3, 3, 3], base=3)
-
-    def test_nonuniform_bases(self):
-        spec = StateSpace([1, 2, 3, 2, 1])
-        self.assertFalse(spec.is_uniform)
-        self.assertEqual([1, 2, 3, 2, 1], spec.base)
-        self.assertEqual(5, spec.ndim)
-        self.assertEqual(12, spec.volume)
+    def test_nonuniform_shape(self):
+        space = StateSpace([1, 2, 3, 2, 1])
+        self.assertEqual(5, space.ndim)
+        self.assertEqual([1, 2, 3, 2, 1], space.shape)
+        self.assertEqual(12, space.volume)
 
     def test_states_boolean(self):
-        space = StateSpace(1)
-        self.assertEqual([[0], [1]],
-                         list(space))
-
-        space = StateSpace(2)
-        self.assertEqual([[0, 0], [1, 0], [0, 1], [1, 1]],
-                         list(space))
-
-        space = StateSpace(3)
-        self.assertEqual([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0],
-                          [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]],
-                         list(space))
-
-    def test_states_nonboolean(self):
-        space = StateSpace(1, base=1)
-        self.assertEqual([[0]],
-                         list(space))
-
-        space = StateSpace(1, base=3)
-        self.assertEqual([[0], [1], [2]],
-                         list(space))
-
-        space = StateSpace(2, base=1)
-        self.assertEqual([[0, 0]],
-                         list(space))
-
-        space = StateSpace(2, base=3)
-        self.assertEqual([[0, 0], [1, 0], [2, 0],
-                          [0, 1], [1, 1], [2, 1],
-                          [0, 2], [1, 2], [2, 2]],
-                         list(space))
-
-    def test_states_boolean_list(self):
         space = StateSpace([2])
-        self.assertEqual([[0], [1]],
-                         list(space))
+        self.assertEqual([[0], [1]], list(space))
 
         space = StateSpace([2, 2])
-        self.assertEqual([[0, 0], [1, 0], [0, 1], [1, 1]],
-                         list(space))
+        self.assertEqual([[0, 0], [1, 0], [0, 1], [1, 1]], list(space))
 
         space = StateSpace([2, 2, 2])
         self.assertEqual([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0],
                           [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]],
                          list(space))
 
-    def test_states_nonboolean_list(self):
+    def test_states_nonboolean(self):
         space = StateSpace([1])
         self.assertEqual([[0]],
                          list(space))
 
         space = StateSpace([3])
         self.assertEqual([[0], [1], [2]],
+                         list(space))
+
+        space = StateSpace([1, 1])
+        self.assertEqual([[0, 0]],
                          list(space))
 
         space = StateSpace([1, 2])
@@ -166,11 +98,11 @@ class TestStateSpace(unittest.TestCase):
         self.assertEqual(np.product(xs), count)
 
     def test_encoding_error(self):
-        space = StateSpace(3)
+        space = StateSpace([2, 2, 2])
         with self.assertRaises(ValueError):
             space.encode([1, 1])
 
-        space = StateSpace(1)
+        space = StateSpace([2])
         with self.assertRaises(ValueError):
             space.encode([2])
 
@@ -184,7 +116,7 @@ class TestStateSpace(unittest.TestCase):
     def test_encoding_uniform(self):
         for width in range(1, 5):
             for base in range(1, 5):
-                space = StateSpace(width, base)
+                space = StateSpace([base] * width)
                 counter = 0
                 for state in space:
                     encoding = space.encode(state)
@@ -205,7 +137,7 @@ class TestStateSpace(unittest.TestCase):
     def test_decoding_uniform(self):
         for width in range(1, 5):
             for base in range(1, 5):
-                space = StateSpace(width, base)
+                space = StateSpace([base] * width)
                 states = list(space)
                 decoded = list(map(space.decode, range(space.volume)))
                 self.assertEqual(states, decoded)
@@ -222,7 +154,7 @@ class TestStateSpace(unittest.TestCase):
     def test_encode_decode_uniform(self):
         for width in range(1, 5):
             for base in range(1, 5):
-                space = StateSpace(width, base)
+                space = StateSpace([base] * width)
                 for state in space:
                     encoded = space.encode(state)
                     decoded = space.decode(encoded)
@@ -241,7 +173,7 @@ class TestStateSpace(unittest.TestCase):
     def test_decode_encode_uniform(self):
         for width in range(1, 5):
             for base in range(1, 5):
-                space = StateSpace(width, base)
+                space = StateSpace([base] * width)
                 for i in range(base**width):
                     decoded = space.decode(i)
                     encoded = space.encode(decoded)
@@ -258,7 +190,7 @@ class TestStateSpace(unittest.TestCase):
                         self.assertEqual(i, encoded)
 
     def test_check_states_uniform(self):
-        state_space = StateSpace(3)
+        state_space = StateSpace([2, 2, 2])
         self.assertTrue([0, 1, 1] in state_space)
         self.assertFalse([0, 0] in state_space)
         self.assertFalse([1, 2, 0] in state_space)
@@ -277,14 +209,167 @@ class TestStateSpace(unittest.TestCase):
         self.assertTrue([1, 1, 6] not in StateSpace([2, 3, 4]))
 
     def test_long_encoding(self):
-        state_space = StateSpace(10)
+        state_space = StateSpace([2] * 10)
         code = state_space.encode(np.ones(10, dtype=int))
         self.assertIsInstance(code, long)
 
-        state_space = StateSpace(68)
+        state_space = StateSpace([2] * 68)
         code = state_space.encode(np.ones(68, dtype=int))
         self.assertIsInstance(code, long)
 
-        state_space = StateSpace(100)
+        state_space = StateSpace([2] * 100)
+        code = state_space.encode(np.ones(100, dtype=int))
+        self.assertIsInstance(code, long)
+
+
+class TestUniformSpace(unittest.TestCase):
+    def test_invalid_ndim_type(self):
+        with self.assertRaises(TypeError):
+            UniformSpace('a', 2)
+
+        with self.assertRaises(TypeError):
+            UniformSpace([2], 2)
+
+        with self.assertRaises(TypeError):
+            UniformSpace(3.0, 2)
+
+    def test_invalid_shape_value(self):
+        with self.assertRaises(ValueError):
+            UniformSpace(0, 2)
+
+        with self.assertRaises(ValueError):
+            UniformSpace(-1, 2)
+
+    def test_shape(self):
+        space = UniformSpace(ndim=5, base=2)
+        self.assertEqual(2, space.base)
+        self.assertEqual(32, space.volume)
+        self.assertEqual(5, space.ndim)
+        self.assertEqual([2, 2, 2, 2, 2], space.shape)
+
+        space = UniformSpace(ndim=8, base=4)
+        self.assertEqual(4, space.base)
+        self.assertEqual(65536, space.volume)
+        self.assertEqual(8, space.ndim)
+        self.assertEqual([4, 4, 4, 4, 4, 4, 4, 4], space.shape)
+
+    def test_states_boolean(self):
+        space = UniformSpace(ndim=1, base=2)
+        self.assertEqual([[0], [1]], list(space))
+
+        space = UniformSpace(ndim=2, base=2)
+        self.assertEqual([[0, 0], [1, 0], [0, 1], [1, 1]], list(space))
+
+        space = UniformSpace(ndim=3, base=2)
+        self.assertEqual([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0],
+                          [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]],
+                         list(space))
+
+    def test_states_nonboolean(self):
+        space = UniformSpace(ndim=1, base=1)
+        self.assertEqual([[0]], list(space))
+
+        space = UniformSpace(ndim=1, base=3)
+        self.assertEqual([[0], [1], [2]], list(space))
+
+        space = UniformSpace(ndim=2, base=1)
+        self.assertEqual([[0, 0]], list(space))
+
+        space = UniformSpace(ndim=2, base=3)
+        self.assertEqual([[0, 0], [1, 0], [2, 0],
+                          [0, 1], [1, 1], [2, 1],
+                          [0, 2], [1, 2], [2, 2]],
+                         list(space))
+
+    def test_states_count(self):
+        space = UniformSpace(ndim=5, base=3)
+        count = 0
+        for state in space:
+            count += 1
+        self.assertEqual(3**5, count)
+
+    def test_encoding_error(self):
+        space = UniformSpace(ndim=3, base=2)
+        with self.assertRaises(ValueError):
+            space.encode([1, 1])
+
+        space = UniformSpace(ndim=1, base=2)
+        with self.assertRaises(ValueError):
+            space.encode([2])
+
+        space = UniformSpace(ndim=2, base=3)
+        with self.assertRaises(ValueError):
+            space.encode([1, 3])
+
+        with self.assertRaises(ValueError):
+            space.encode([1, -1])
+
+    def test_encoding(self):
+        for ndim in range(1, 5):
+            for base in range(1, 5):
+                space = UniformSpace(ndim, base)
+                counter = 0
+                for state in space:
+                    encoding = space.encode(state)
+                    self.assertEqual(counter, encoding)
+                    counter += 1
+
+    def test_decoding(self):
+        for ndim in range(1, 5):
+            for base in range(1, 5):
+                space = UniformSpace(ndim, base)
+                states = list(space)
+                decoded = list(map(space.decode, range(space.volume)))
+                self.assertEqual(states, decoded)
+
+    def test_encode_decode(self):
+        for ndim in range(1, 5):
+            for base in range(1, 5):
+                space = UniformSpace(ndim, base)
+                for state in space:
+                    encoded = space.encode(state)
+                    decoded = space.decode(encoded)
+                    self.assertEqual(state, decoded)
+
+    def test_decode_encode(self):
+        for ndim in range(1, 5):
+            for base in range(1, 5):
+                space = UniformSpace(ndim, base)
+                for i in range(base**ndim):
+                    decoded = space.decode(i)
+                    encoded = space.encode(decoded)
+                    self.assertEqual(i, encoded)
+
+    def test_check_states(self):
+        state_space = UniformSpace(ndim=3, base=2)
+        self.assertTrue([0, 1, 1] in state_space)
+        self.assertFalse([0, 0] in state_space)
+        self.assertFalse([1, 2, 0] in state_space)
+
+        self.assertFalse([0, 1, 1] not in state_space)
+        self.assertTrue([0, 0] not in state_space)
+        self.assertTrue([1, 2, 0] not in state_space)
+
+        state_space = UniformSpace(ndim=3, base=3)
+        self.assertTrue([0, 1, 1] in state_space)
+        self.assertFalse([0, 0] in state_space)
+        self.assertTrue([1, 2, 0] in state_space)
+        self.assertFalse([1, 2, 3] in state_space)
+
+        self.assertFalse([0, 1, 1] not in state_space)
+        self.assertTrue([0, 0] not in state_space)
+        self.assertFalse([1, 2, 0] not in state_space)
+        self.assertTrue([1, 2, 3] not in state_space)
+
+    def test_long_encoding(self):
+        state_space = UniformSpace(ndim=10, base=2)
+        code = state_space.encode(np.ones(10, dtype=int))
+        self.assertIsInstance(code, long)
+
+        state_space = UniformSpace(ndim=68, base=2)
+        code = state_space.encode(np.ones(68, dtype=int))
+        self.assertIsInstance(code, long)
+
+        state_space = UniformSpace(ndim=100, base=2)
         code = state_space.encode(np.ones(100, dtype=int))
         self.assertIsInstance(code, long)

--- a/test/test_statespace.py
+++ b/test/test_statespace.py
@@ -1,6 +1,6 @@
 import unittest
 from neet.python import long
-from neet.statespace import StateSpace, UniformSpace
+from neet.statespace import StateSpace, UniformSpace, BooleanSpace
 import numpy as np
 
 
@@ -240,6 +240,23 @@ class TestUniformSpace(unittest.TestCase):
         with self.assertRaises(ValueError):
             UniformSpace(-1, 2)
 
+    def test_invalid_base_type(self):
+        with self.assertRaises(TypeError):
+            UniformSpace(5, 'a')
+
+        with self.assertRaises(TypeError):
+            UniformSpace(5, [2])
+
+        with self.assertRaises(TypeError):
+            UniformSpace(5, 3.0)
+
+    def test_invalid_base_value(self):
+        with self.assertRaises(ValueError):
+            UniformSpace(5, 0)
+
+        with self.assertRaises(ValueError):
+            UniformSpace(5, -1)
+
     def test_shape(self):
         space = UniformSpace(ndim=5, base=2)
         self.assertEqual(2, space.base)
@@ -371,5 +388,121 @@ class TestUniformSpace(unittest.TestCase):
         self.assertIsInstance(code, long)
 
         state_space = UniformSpace(ndim=100, base=2)
+        code = state_space.encode(np.ones(100, dtype=int))
+        self.assertIsInstance(code, long)
+
+
+class TestBooleanSpace(unittest.TestCase):
+    def test_invalid_ndim_type(self):
+        with self.assertRaises(TypeError):
+            BooleanSpace('a')
+
+        with self.assertRaises(TypeError):
+            BooleanSpace([2])
+
+        with self.assertRaises(TypeError):
+            BooleanSpace(3.0)
+
+    def test_invalid_shape_value(self):
+        with self.assertRaises(ValueError):
+            BooleanSpace(0)
+
+        with self.assertRaises(ValueError):
+            BooleanSpace(-1)
+
+    def test_shape(self):
+        space = BooleanSpace(5)
+        self.assertEqual(2, space.base)
+        self.assertEqual(32, space.volume)
+        self.assertEqual(5, space.ndim)
+        self.assertEqual([2, 2, 2, 2, 2], space.shape)
+
+    def test_states(self):
+        space = BooleanSpace(1)
+        self.assertEqual([[0], [1]], list(space))
+
+        space = BooleanSpace(2)
+        self.assertEqual([[0, 0], [1, 0], [0, 1], [1, 1]], list(space))
+
+        space = BooleanSpace(3)
+        self.assertEqual([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0],
+                          [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]],
+                         list(space))
+
+    def test_states_count(self):
+        space = BooleanSpace(5)
+        count = 0
+        for state in space:
+            count += 1
+        self.assertEqual(32, count)
+
+    def test_encoding_error(self):
+        space = BooleanSpace(3)
+        with self.assertRaises(ValueError):
+            space.encode([1, 1])
+
+        space = BooleanSpace(1)
+        with self.assertRaises(ValueError):
+            space.encode([2])
+
+        space = BooleanSpace(2)
+        with self.assertRaises(ValueError):
+            space.encode([1, 3])
+
+        with self.assertRaises(ValueError):
+            space.encode([1, -1])
+
+    def test_encoding(self):
+        for ndim in range(1, 5):
+            space = BooleanSpace(ndim)
+            counter = 0
+            for state in space:
+                encoding = space.encode(state)
+                self.assertEqual(counter, encoding)
+                counter += 1
+
+    def test_decoding(self):
+        for ndim in range(1, 5):
+            space = BooleanSpace(ndim)
+            states = list(space)
+            decoded = list(map(space.decode, range(space.volume)))
+            self.assertEqual(states, decoded)
+
+    def test_encode_decode(self):
+        for ndim in range(1, 5):
+            space = BooleanSpace(ndim)
+            for state in space:
+                encoded = space.encode(state)
+                decoded = space.decode(encoded)
+                self.assertEqual(state, decoded)
+
+    def test_decode_encode(self):
+        for ndim in range(1, 5):
+            space = BooleanSpace(ndim)
+            for i in range(2**ndim):
+                decoded = space.decode(i)
+                encoded = space.encode(decoded)
+                self.assertEqual(i, encoded)
+
+    def test_check_states(self):
+        state_space = BooleanSpace(3)
+        self.assertTrue([0, 1, 1] in state_space)
+        self.assertFalse([0, 0] in state_space)
+        self.assertFalse([1, 2, 0] in state_space)
+
+        self.assertFalse([0, 1, 1] not in state_space)
+        self.assertTrue([0, 0] not in state_space)
+        self.assertTrue([1, 2, 0] not in state_space)
+
+    def test_long_encoding(self):
+        state_space = BooleanSpace(10)
+        code = state_space.encode(np.ones(10, dtype=int))
+        self.assertIsInstance(code, long)
+
+        state_space = BooleanSpace(68)
+        code = state_space.encode(np.ones(68, dtype=int))
+        self.assertIsInstance(code, long)
+
+        state_space = BooleanSpace(100)
         code = state_space.encode(np.ones(100, dtype=int))
         self.assertIsInstance(code, long)


### PR DESCRIPTION
This pull request introduces two new classes which (ultimately) derive from `neet.statespace.StateSpace`:
1. `neet.statespace.UniformSpace` - a state space with the same base in each dimension
2. `neet.statespace.BooleanSpace` - a state space with base-2 dimensions

This allows for slightly better performance. More importantly, it allows for smaller, clearer implementations of the various `StateSpace` methods that had already been implemented. Each subclass overrides the general methods in `StateSpace` to provide more specific implementations.

This closes #136 .