### PR TITLE
basic landscape visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
 .hypothesis/
 
 # Translations
@@ -93,3 +93,6 @@ ENV/
 
 # Visual Studio Code
 .vscode
+
+#Mac
+*.DS_Store

--- a/examples/basic-examples.ipynb
+++ b/examples/basic-examples.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -31,7 +31,7 @@
        "9"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -58,7 +58,7 @@
        "[0, 1, 0, 0, 0, 0, 0, 0, 0]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -108,7 +108,7 @@
        "       0.11236749, 0.24586519, 0.24586519, 0.02025117])"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -129,7 +129,7 @@
        "0.009288397587760126"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -149,18 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "import neet.sensitivity as ns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -169,13 +158,13 @@
        "0.9513888888888888"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ns.average_sensitivity(s_pombe)"
+    "s_pombe.average_sensitivity()"
    ]
   },
   {
@@ -187,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -206,13 +195,13 @@
        " (8, 4)}"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ns.canalizing_edges(s_pombe)"
+    "s_pombe.canalizing_edges()"
    ]
   },
   {
@@ -224,21 +213,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_pombe.draw(labels='names')"
+    "s_pombe.draw(graphkwargs={'labels':'names'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An image of the attractor landscape can similarly be generated."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from neet.synchronous import Landscape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "landscape = Landscape(s_pombe)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "landscape.draw()"
+   ]
   }
  ],
  "metadata": {
@@ -257,7 +271,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/neet/boolean/network.py
+++ b/neet/boolean/network.py
@@ -21,7 +21,6 @@ class BooleanNetwork(SensitivityMixin, UniformNetwork):
         super(BooleanNetwork, self).__init__(size, 2, names, metadata)
 
     def __iter__(self):
-        print "yes"
         size = self.size
         state = [0] * size
         yield state[:]

--- a/neet/boolean/network.py
+++ b/neet/boolean/network.py
@@ -21,6 +21,7 @@ class BooleanNetwork(SensitivityMixin, UniformNetwork):
         super(BooleanNetwork, self).__init__(size, 2, names, metadata)
 
     def __iter__(self):
+        print "yes"
         size = self.size
         state = [0] * size
         yield state[:]

--- a/neet/network.py
+++ b/neet/network.py
@@ -100,7 +100,7 @@ class Network(StateSpace):
             outputs = self.neighbors_out(index, *args, **kwargs)
             return inputs.union(outputs)
 
-    def to_networkx_graph(self, labels='indices', *args, **kwargs):
+    def to_networkx_graph(self, labels='indices', **kwargs):
         if labels == 'indices':
             edges = [(i, j) for i in range(self.size) for j in self.neighbors_out(i)]
         elif labels == 'names' and self.names is not None:
@@ -114,9 +114,9 @@ class Network(StateSpace):
         kwargs.update(self.metadata)
         return nx.DiGraph(edges, **kwargs)
 
-    def draw(self, graphargs=dict(), graphkwargs=dict(), pygraphargs=dict(), pygraphkwargs={'prog':'circo'}):
-        graph = self.to_networkx_graph(*graphargs, **graphkwargs)
-        nx.nx_agraph.view_pygraphviz(graph, *pygraphargs, **pygraphkwargs)
+    def draw(self, graphkwargs=dict(), pygraphkwargs={'prog':'circo'}):
+        graph = self.to_networkx_graph(**graphkwargs)
+        nx.nx_agraph.view_pygraphviz(graph,**pygraphkwargs)
 
 class UniformNetwork(Network):
     def __init__(self, size, base, names=None, metadata=None):

--- a/neet/network.py
+++ b/neet/network.py
@@ -114,10 +114,9 @@ class Network(StateSpace):
         kwargs.update(self.metadata)
         return nx.DiGraph(edges, **kwargs)
 
-    def draw(self, filename=None, *args, **kwargs):
-        graph = self.to_networkx_graph(*args, **kwargs)
-        nx.nx_agraph.view_pygraphviz(graph, prog='circo', path=filename)
-
+    def draw(self, graphargs=dict(), graphkwargs=dict(), pygraphargs=dict(), pygraphkwargs={'prog':'circo'}):
+        graph = self.to_networkx_graph(*graphargs, **graphkwargs)
+        nx.nx_agraph.view_pygraphviz(graph, *pygraphargs, **pygraphkwargs)
 
 class UniformNetwork(Network):
     def __init__(self, size, base, names=None, metadata=None):

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -636,3 +636,15 @@ class Landscape(StateSpace):
             self.__expound()
         dist = pi.Dist(self.__basin_sizes)
         return pi.shannon.entropy(dist, b=base)
+
+    def draw(self, pygraphkwargs={'prog':'dot'}):
+        """
+        Draw networkx graph using PyGraphviz. 
+        
+        Requires graphviz (cannot be installed via pip--see: 
+        https://graphviz.gitlab.io/download/) and pygraphviz 
+        (can be installed via pip).
+
+        :param pygraphkwargs: kwargs to pass to view_pygraphviz
+        """
+        nx.nx_agraph.view_pygraphviz(self.__graph, **pygraphkwargs)

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -647,4 +647,6 @@ class Landscape(StateSpace):
 
         :param pygraphkwargs: kwargs to pass to view_pygraphviz
         """
+        if not self.__graph:
+            self.graph
         nx.nx_agraph.view_pygraphviz(self.__graph, **pygraphkwargs)


### PR DESCRIPTION
After a lot of tinkering around, there just isn't a better way to visualize landscapes than what we were already doing for the networks themselves. Unfortunately no pure python packages exist which are good at this, so we continue to lean on graphviz+pygraphviz.

Would be nice to add some built in visualizations for highlighting attractor states or particular paths, but these can still be accomplished manually by the user.

This will have to be modified slightly once we update to the `Landscape` class to be `LandscapeMixin`.

Addresses #128 