### PR TITLE
Extend the LandscapeMixin

### DIFF
--- a/neet/boolean/eca.py
+++ b/neet/boolean/eca.py
@@ -86,6 +86,7 @@ class ECA(BooleanNetwork):
             raise TypeError("ECA code is not an int")
         if 255 < code or code < 0:
             raise ValueError("invalid ECA code")
+        self.clear_landscape()
         self.__code = code
 
     @property
@@ -101,6 +102,7 @@ class ECA(BooleanNetwork):
         self._size = size
         self._volume = 2**size
         self._shape = [2] * size
+        self.clear_landscape()
 
     @property
     def boundary(self):
@@ -140,6 +142,7 @@ class ECA(BooleanNetwork):
                 if x != 0 and x != 1:
                     raise ValueError("invalid ECA boundary value")
         self.__boundary = boundary
+        self.clear_landscape()
 
     def _unsafe_update(self, lattice, index=None, pin=None, values=None):
         """

--- a/neet/boolean/reca.py
+++ b/neet/boolean/reca.py
@@ -140,6 +140,7 @@ class RewiredECA(BooleanNetwork):
         if 255 < code or code < 0:
             raise ValueError("invalid ECA code")
         self.__code = code
+        self.clear_landscape()
 
     @property
     def boundary(self):
@@ -179,6 +180,7 @@ class RewiredECA(BooleanNetwork):
                 if x != 0 and x != 1:
                     raise ValueError("invalid ECA boundary value")
         self.__boundary = boundary
+        self.clear_landscape()
 
     @property
     def wiring(self):

--- a/neet/network.py
+++ b/neet/network.py
@@ -30,7 +30,6 @@ class Network(LandscapeMixin, StateSpace):
 
         self._metadata = metadata
         self.names = names
-        self._landscaped = False
 
     @property
     def metadata(self):

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -53,6 +53,10 @@ class LandscapeMixin:
     __landscaped = False
     __landscape_data = LandscapeData()
 
+    def clear_landscape(self):
+        self.__landscaped = False
+        self.__landscape_data = LandscapeData()
+
     def landscape(self, index=None, pin=None, values=None):
         """
         Construct the landscape for a network.
@@ -73,7 +77,6 @@ class LandscapeMixin:
         :raises TypeError: if ``net`` is not a network
         """
 
-        self.__landscape_data = LandscapeData()
         self.__index = index
         self.__pin = pin
         self.__values = values
@@ -91,6 +94,7 @@ class LandscapeMixin:
                                            pin=self.__pin,
                                            values=self.__values))
 
+        self.clear_landscape()
         self.__landscape_data.transitions = transitions
         self.__landscaped = True
 

--- a/neet/synchronous.py
+++ b/neet/synchronous.py
@@ -111,7 +111,7 @@ class LandscapeMixin:
         """
         if not self._landscaped:
             self.landscape()
-        if self.__data.attractors is None:
+        if not self.__expounded:
             self.__expound()
         return self.__data.attractors
 
@@ -134,7 +134,7 @@ class LandscapeMixin:
         """
         if not self._landscaped:
             self.landscape()
-        if self.__data.basins is None:
+        if not self.__expounded:
             self.__expound()
         return self.__data.basins
 
@@ -153,7 +153,7 @@ class LandscapeMixin:
         """
         if not self._landscaped:
             self.landscape()
-        if self.__data.basin_sizes is None:
+        if not self.__expounded:
             self.__expound()
         return self.__data.basin_sizes
 
@@ -176,7 +176,7 @@ class LandscapeMixin:
         """
         if not self._landscaped:
             self.landscape()
-        if self.__data.in_degrees is None:
+        if not self.__expounded:
             self.__expound()
         return self.__data.in_degrees
 
@@ -202,7 +202,7 @@ class LandscapeMixin:
         """
         if not self._landscaped:
             self.landscape()
-        if self.__data.heights is None:
+        if not self.__expounded:
             self.__expound()
         return self.__data.heights
 
@@ -222,7 +222,7 @@ class LandscapeMixin:
         """
         if not self._landscaped:
             self.landscape()
-        if self.__data.attractor_lengths is None:
+        if not self.__expounded:
             self.__expound()
         return self.__data.attractor_lengths
 
@@ -248,7 +248,7 @@ class LandscapeMixin:
         """
         if not self._landscaped:
             self.landscape()
-        if self.__data.recurrence_times is None:
+        if not self.__expounded:
             self.__expound()
         return self.__data.recurrence_times
 
@@ -638,7 +638,7 @@ class LandscapeMixin:
         """
         if not self._landscaped:
             self.landscape()
-        if self.__data.basin_sizes is None:
+        if not self.__expounded:
             self.__expound()
         dist = pi.Dist(self.__data.basin_sizes)
         return pi.shannon.entropy(dist, b=base)

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -15,6 +15,11 @@ class TestLandscape(unittest.TestCase):
         """
         self.assertTrue(True)
 
+    def tearDown(self):
+        s_pombe.clear_landscape()
+        s_cerevisiae.clear_landscape()
+        c_elegans.clear_landscape()
+
     def test_transitions_eca(self):
         net = ECA(30, 1)
         self.assertEqual([0, 0], list(net.transitions))
@@ -411,6 +416,7 @@ class TestLandscape(unittest.TestCase):
             histogram = [0] * (np.max(basins) + 1)
             for b in basins:
                 histogram[b] += 1
+            net.clear_landscape()
             self.assertEqual(histogram, list(net.basin_sizes))
 
     def test_basin_entropy_eca(self):
@@ -457,12 +463,14 @@ class TestLandscape(unittest.TestCase):
                 for i in range(net.volume):
                     in_degrees[i] = np.count_nonzero(
                         net.transitions == i)
+                net.clear_landscape()
                 self.assertEqual(list(in_degrees), list(net.in_degrees))
 
         for net in [s_pombe, s_cerevisiae, c_elegans]:
             in_degrees = np.empty(net.volume, dtype=np.int)
             for i in range(net.volume):
                 in_degrees[i] = np.count_nonzero(net.transitions == i)
+            net.clear_landscape()
             self.assertEqual(list(in_degrees), list(net.in_degrees))
 
     def test_heights(self):
@@ -476,6 +484,7 @@ class TestLandscape(unittest.TestCase):
                     while state not in net.attractors[b]:
                         heights[i] += 1
                         state = net.transitions[state]
+                net.clear_landscape()
                 self.assertEqual(heights, list(net.heights))
 
         for net in [s_pombe, s_cerevisiae, c_elegans]:
@@ -486,6 +495,7 @@ class TestLandscape(unittest.TestCase):
                 while state not in net.attractors[b]:
                     heights[i] += 1
                     state = net.transitions[state]
+            net.clear_landscape()
             self.assertEqual(heights, list(net.heights))
 
     def test_attractor_lengths(self):
@@ -493,10 +503,12 @@ class TestLandscape(unittest.TestCase):
             for size in range(2, 7):
                 net = ECA(code, size)
                 lengths = list(map(len, net.attractors))
+                net.clear_landscape()
                 self.assertEqual(lengths, list(net.attractor_lengths))
 
         for net in [s_pombe, s_cerevisiae, c_elegans]:
             lengths = list(map(len, net.attractors))
+            net.clear_landscape()
             self.assertEqual(lengths, list(net.attractor_lengths))
 
     def test_recurrence_times(self):
@@ -508,6 +520,7 @@ class TestLandscape(unittest.TestCase):
                     b = net.basins[i]
                     recurrence_times[i] = net.heights[i] + \
                         net.attractor_lengths[b] - 1
+                net.clear_landscape()
                 self.assertEqual(recurrence_times, list(
                     net.recurrence_times))
 
@@ -517,6 +530,7 @@ class TestLandscape(unittest.TestCase):
                 b = net.basins[i]
                 recurrence_times[i] = net.heights[i] + \
                     net.attractor_lengths[b] - 1
+            net.clear_landscape()
             self.assertEqual(recurrence_times, list(
                 net.recurrence_times))
 
@@ -544,6 +558,23 @@ class TestLandscape(unittest.TestCase):
             "basin_entropy"
         ]))
         self.assertEqual(set(data_after_expound.__dict__.keys()), set([
+            "transitions",
+            "basins",
+            "basin_sizes",
+            "attractors",
+            "attractor_lengths",
+            "in_degrees",
+            "heights",
+            "recurrence_times",
+            "basin_entropy"
+        ]))
+
+    def test_expound(self):
+        net = ECA(30, size=5)
+        before = net.landscape_data
+        after = net.expound().landscape_data
+        self.assertEqual(before.__dict__, {})
+        self.assertEqual(set(after.__dict__.keys()), set([
             "transitions",
             "basins",
             "basin_sizes",

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -16,26 +16,17 @@ class TestLandscape(unittest.TestCase):
         self.assertTrue(True)
 
     def test_transitions_eca(self):
-        ca = ECA(30, 1)
+        net = ECA(30, 1)
+        self.assertEqual([0, 0], list(net.transitions))
 
-        landscape = ca.landscape()
-        self.assertEqual(1, landscape.size)
-        self.assertEqual([0, 0], list(landscape.transitions))
+        net.size = 2
+        self.assertEqual([0, 1, 2, 0], list(net.transitions))
 
-        ca.size = 2
-        landscape = ca.landscape()
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([0, 1, 2, 0], list(landscape.transitions))
+        net.size = 3
+        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(net.transitions))
 
-        ca.size = 3
-        landscape = ca.landscape()
-        self.assertEqual(3, landscape.size)
-        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(landscape.transitions))
-
-        ca.size = 10
-        landscape = ca.landscape()
-        trans = landscape.transitions
-        self.assertEqual(10, landscape.size)
+        net.size = 10
+        trans = net.transitions
         self.assertEqual(1024, len(trans))
         self.assertEqual([0, 515, 7, 517, 14, 525, 11,
                           521, 28, 543], list(trans[:10]))
@@ -43,46 +34,37 @@ class TestLandscape(unittest.TestCase):
                          list(trans[-10:]))
 
     def test_transitions_eca_index(self):
-        ca = ECA(30, 3)
-        landscape = ca.landscape(index=1)
-        self.assertEqual(3, landscape.size)
-        self.assertEqual([0, 3, 2, 1, 6, 5, 6, 5], list(landscape.transitions))
+        net = ECA(30, 3)
+        net.landscape(index=1)
+        self.assertEqual([0, 3, 2, 1, 6, 5, 6, 5], list(net.transitions))
 
-        landscape = ca.landscape(index=0)
-        self.assertEqual(3, landscape.size)
-        self.assertEqual([0, 1, 3, 3, 5, 4, 6, 6], list(landscape.transitions))
+        net.landscape(index=0)
+        self.assertEqual([0, 1, 3, 3, 5, 4, 6, 6], list(net.transitions))
 
-        landscape = ca.landscape(index=None)
-        self.assertEqual(3, landscape.size)
-        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(landscape.transitions))
+        net.landscape(index=None)
+        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(net.transitions))
 
     def test_transitions_eca_pin(self):
-        ca = ECA(30, 3)
-        landscape = ca.landscape(pin=[1])
-        self.assertEqual(3, landscape.size)
-        self.assertEqual([0, 5, 7, 3, 5, 4, 2, 2], list(landscape.transitions))
+        net = ECA(30, 3)
+        net.landscape(pin=[1])
+        self.assertEqual([0, 5, 7, 3, 5, 4, 2, 2], list(net.transitions))
 
-        landscape = ca.landscape(pin=[0])
-        self.assertEqual(3, landscape.size)
-        self.assertEqual([0, 7, 6, 1, 6, 5, 2, 1], list(landscape.transitions))
+        net.landscape(pin=[0])
+        self.assertEqual([0, 7, 6, 1, 6, 5, 2, 1], list(net.transitions))
 
-        landscape = ca.landscape(pin=None)
-        self.assertEqual(3, landscape.size)
-        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(landscape.transitions))
+        net.landscape(pin=None)
+        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(net.transitions))
 
     def test_transitions_eca_values(self):
-        ca = ECA(30, 3)
-        landscape = ca.landscape(values={0: 1})
-        self.assertEqual(3, landscape.size)
-        self.assertEqual([1, 7, 7, 1, 7, 5, 3, 1], list(landscape.transitions))
+        net = ECA(30, 3)
+        net.landscape(values={0: 1})
+        self.assertEqual([1, 7, 7, 1, 7, 5, 3, 1], list(net.transitions))
 
-        landscape = ca.landscape(values={1: 0})
-        self.assertEqual(3, landscape.size)
-        self.assertEqual([0, 5, 5, 1, 5, 4, 0, 0], list(landscape.transitions))
+        net.landscape(values={1: 0})
+        self.assertEqual([0, 5, 5, 1, 5, 4, 0, 0], list(net.transitions))
 
-        landscape = ca.landscape(values={})
-        self.assertEqual(3, landscape.size)
-        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(landscape.transitions))
+        net.landscape(values={})
+        self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(net.transitions))
 
     def test_transitions_wtnetwork(self):
         net = WTNetwork(
@@ -91,9 +73,7 @@ class TestLandscape(unittest.TestCase):
             theta=WTNetwork.positive_threshold
         )
 
-        landscape = net.landscape()
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
+        self.assertEqual([2, 1, 2, 3], list(net.transitions))
 
     def test_transitions_wtnetwork_index(self):
         net = WTNetwork(
@@ -102,17 +82,14 @@ class TestLandscape(unittest.TestCase):
             theta=WTNetwork.positive_threshold
         )
 
-        landscape = net.landscape(index=1)
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
+        net.landscape(index=1)
+        self.assertEqual([2, 1, 2, 3], list(net.transitions))
 
-        landscape = net.landscape(index=0)
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([0, 1, 2, 3], list(landscape.transitions))
+        net.landscape(index=0)
+        self.assertEqual([0, 1, 2, 3], list(net.transitions))
 
-        landscape = net.landscape(index=None)
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
+        net.landscape(index=None)
+        self.assertEqual([2, 1, 2, 3], list(net.transitions))
 
     def test_transitions_wtnetwork_pin(self):
         net = WTNetwork(
@@ -121,17 +98,14 @@ class TestLandscape(unittest.TestCase):
             theta=WTNetwork.positive_threshold
         )
 
-        landscape = net.landscape(pin=[1])
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([0, 1, 2, 3], list(landscape.transitions))
+        net.landscape(pin=[1])
+        self.assertEqual([0, 1, 2, 3], list(net.transitions))
 
-        landscape = net.landscape(pin=[0])
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
+        net.landscape(pin=[0])
+        self.assertEqual([2, 1, 2, 3], list(net.transitions))
 
-        landscape = net.landscape(pin=None)
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
+        net.landscape(pin=None)
+        self.assertEqual([2, 1, 2, 3], list(net.transitions))
 
     def test_transitions_wtnetwork_values(self):
         net = WTNetwork(
@@ -140,93 +114,65 @@ class TestLandscape(unittest.TestCase):
             theta=WTNetwork.positive_threshold
         )
 
-        landscape = net.landscape(values={0: 1})
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([3, 1, 3, 3], list(landscape.transitions))
+        net.landscape(values={0: 1})
+        self.assertEqual([3, 1, 3, 3], list(net.transitions))
 
-        landscape = net.landscape(values={1: 0})
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([0, 1, 0, 1], list(landscape.transitions))
+        net.landscape(values={1: 0})
+        self.assertEqual([0, 1, 0, 1], list(net.transitions))
 
-        landscape = net.landscape(values={})
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
+        net.landscape(values={})
+        self.assertEqual([2, 1, 2, 3], list(net.transitions))
 
     def test_transitions_logicnetwork(self):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
 
-        landscape = net.landscape()
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([1, 3, 1, 3], list(landscape.transitions))
+        self.assertEqual([1, 3, 1, 3], list(net.transitions))
 
     def test_transitions_logicnetwork_index(self):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
 
-        landscape = net.landscape(index=1)
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([0, 3, 0, 3], list(landscape.transitions))
+        net.landscape(index=1)
+        self.assertEqual([0, 3, 0, 3], list(net.transitions))
 
-        landscape = net.landscape(index=0)
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([1, 1, 3, 3], list(landscape.transitions))
+        net.landscape(index=0)
+        self.assertEqual([1, 1, 3, 3], list(net.transitions))
 
-        landscape = net.landscape(index=None)
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([1, 3, 1, 3], list(landscape.transitions))
+        net.landscape(index=None)
+        self.assertEqual([1, 3, 1, 3], list(net.transitions))
 
     def test_transitions_logicnetwork_pin(self):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
 
-        landscape = net.landscape(pin=[1])
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([1, 1, 3, 3], list(landscape.transitions))
+        net.landscape(pin=[1])
+        self.assertEqual([1, 1, 3, 3], list(net.transitions))
 
-        landscape = net.landscape(pin=[0])
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([0, 3, 0, 3], list(landscape.transitions))
+        net.landscape(pin=[0])
+        self.assertEqual([0, 3, 0, 3], list(net.transitions))
 
-        landscape = net.landscape(pin=None)
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([1, 3, 1, 3], list(landscape.transitions))
+        net.landscape(pin=None)
+        self.assertEqual([1, 3, 1, 3], list(net.transitions))
 
     def test_transitions_logicnetwork_values(self):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
 
-        landscape = net.landscape(values={0: 1})
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([1, 3, 1, 3], list(landscape.transitions))
+        net.landscape(values={0: 1})
+        self.assertEqual([1, 3, 1, 3], list(net.transitions))
 
-        landscape = net.landscape(values={1: 0})
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([1, 1, 1, 1], list(landscape.transitions))
+        net.landscape(values={1: 0})
+        self.assertEqual([1, 1, 1, 1], list(net.transitions))
 
-        landscape = net.landscape(values={})
-        self.assertEqual(2, landscape.size)
-        self.assertEqual([1, 3, 1, 3], list(landscape.transitions))
+        net.landscape(values={})
+        self.assertEqual([1, 3, 1, 3], list(net.transitions))
 
         # Add more test for different thetas?
 
     def test_transitions_spombe(self):
-        landscape = s_pombe.landscape()
-        self.assertEqual(9, landscape.size)
-        trans = landscape.transitions
+        trans = s_pombe.transitions
         self.assertEqual(512, len(trans))
         self.assertEqual([2, 2, 130, 130, 4, 0, 128,
                           128, 8, 0], list(trans[:10]))
         self.assertEqual([464, 464, 344, 336, 464, 464, 348,
                           336, 464, 464], list(trans[-10:]))
-
-    def test_is_state_space(self):
-        landscape = s_pombe.landscape()
-        self.assertEqual(list(s_pombe), list(landscape))
-        self.assertEqual([s_pombe.encode(state) for state in s_pombe],
-                         list(map(landscape.encode, landscape)))
-
-        ca = ECA(30, 10)
-        landscape = ca.landscape()
-        self.assertEqual(list(ca), list(landscape))
-        self.assertEqual([ca.encode(state) for state in ca],
-                         list(map(landscape.encode, landscape)))
 
     def test_attractors_eca(self):
         networks = [(ECA(30, 2), 3), (ECA(30, 3), 1), (ECA(30, 4), 4),
@@ -235,8 +181,7 @@ class TestLandscape(unittest.TestCase):
                     (ECA(110, 6), 3)]
 
         for rule, size in networks:
-            landscape = rule.landscape()
-            self.assertEqual(size, len(landscape.attractors))
+            self.assertEqual(size, len(rule.attractors))
 
     def test_basins_eca(self):
         networks = [(ECA(30, 2), 3), (ECA(30, 3), 1), (ECA(30, 4), 4),
@@ -245,88 +190,86 @@ class TestLandscape(unittest.TestCase):
                     (ECA(110, 6), 3)]
 
         for rule, size in networks:
-            landscape = rule.landscape()
-            self.assertEqual(landscape.volume, len(landscape.basins))
-            self.assertEqual(size, 1 + np.max(landscape.basins))
+            self.assertEqual(rule.volume, len(rule.basins))
+            self.assertEqual(size, 1 + np.max(rule.basins))
 
-            unique = list(set(landscape.basins))
+            unique = list(set(rule.basins))
             unique.sort()
             self.assertEqual(list(range(size)), unique)
 
     def test_attractors_wtnetworks(self):
         networks = [(s_pombe, 13), (s_cerevisiae, 7), (c_elegans, 5)]
         for net, size in networks:
-            landscape = net.landscape()
-            self.assertEqual(size, len(landscape.attractors))
-            self.assertEqual(landscape.volume, len(landscape.basins))
-            self.assertEqual(size, 1 + np.max(landscape.basins))
+            self.assertEqual(size, len(net.attractors))
+            self.assertEqual(net.volume, len(net.basins))
+            self.assertEqual(size, 1 + np.max(net.basins))
 
-            unique = list(set(landscape.basins))
+            unique = list(set(net.basins))
             unique.sort()
             self.assertEqual(list(range(size)), unique)
 
     def test_trajectory_too_short(self):
-        landscape = ECA(30, 3).landscape()
+        net = ECA(30, 3)
         with self.assertRaises(ValueError):
-            landscape.trajectory([0, 0, 0], timesteps=-1)
+            net.trajectory([0, 0, 0], timesteps=-1)
 
         with self.assertRaises(ValueError):
-            landscape.trajectory([0, 0, 0], timesteps=0)
+            net.trajectory([0, 0, 0], timesteps=0)
 
     def test_trajectory_eca(self):
-        landscape = ECA(30, 3).landscape()
+        net = ECA(30, 3)
 
         with self.assertRaises(ValueError):
-            landscape.trajectory([])
+            net.trajectory([])
 
         with self.assertRaises(ValueError):
-            landscape.trajectory([0, 1])
+            net.trajectory([0, 1])
 
         xs = [0, 1, 0]
 
-        got = landscape.trajectory(xs)
+        got = net.trajectory(xs)
         self.assertEqual([0, 1, 0], xs)
         self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0]], got)
 
-        got = landscape.trajectory(xs, timesteps=5)
+        got = net.trajectory(xs, timesteps=5)
         self.assertEqual([0, 1, 0], xs)
         self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0],
                           [0, 0, 0], [0, 0, 0], [0, 0, 0]], got)
 
-        got = landscape.trajectory(xs, encode=False)
+        got = net.trajectory(xs, encode=False)
         self.assertEqual([0, 1, 0], xs)
         self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0]], got)
 
-        got = landscape.trajectory(xs, timesteps=5, encode=False)
+        got = net.trajectory(xs, timesteps=5, encode=False)
         self.assertEqual([0, 1, 0], xs)
         self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0],
                           [0, 0, 0], [0, 0, 0], [0, 0, 0]], got)
 
-        got = landscape.trajectory(xs, encode=True)
+        got = net.trajectory(xs, encode=True)
         self.assertEqual([0, 1, 0], xs)
         self.assertEqual([2, 7, 0], list(got))
 
-        got = landscape.trajectory(xs, timesteps=5, encode=True)
+        got = net.trajectory(xs, timesteps=5, encode=True)
         self.assertEqual([0, 1, 0], xs)
         self.assertEqual([2, 7, 0, 0, 0, 0], list(got))
 
         xs = 2
-        got = landscape.trajectory(xs)
+        got = net.trajectory(xs)
         self.assertEqual([2, 7, 0], list(got))
 
-        got = landscape.trajectory(xs, timesteps=5)
+        got = net.trajectory(xs, timesteps=5)
         self.assertEqual([2, 7, 0, 0, 0, 0], list(got))
 
-        got = landscape.trajectory(xs, encode=True)
+        got = net.trajectory(xs, encode=True)
         self.assertEqual([2, 7, 0], list(got))
 
-        got = landscape.trajectory(xs, timesteps=5, encode=True)
+        got = net.trajectory(xs, timesteps=5, encode=True)
         self.assertEqual([2, 7, 0, 0, 0, 0], list(got))
 
-        got = landscape.trajectory(xs, encode=False)
+        got = net.trajectory(xs, encode=False)
         self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0]], got)
 
-        got = landscape.trajectory(xs, timesteps=5, encode=False)
+        got = net.trajectory(xs, timesteps=5, encode=False)
         self.assertEqual([[0, 1, 0], [1, 1, 1], [0, 0, 0],
                           [0, 0, 0], [0, 0, 0], [0, 0, 0]], got)
 
@@ -337,50 +280,48 @@ class TestLandscape(unittest.TestCase):
             theta=WTNetwork.positive_threshold
         )
 
-        landscape = net.landscape()
-
         state = [0, 0]
-        got = landscape.trajectory(state)
+        got = net.trajectory(state)
         self.assertEqual([0, 0], state)
         self.assertEqual([[0, 0], [0, 1]], got)
 
-        got = landscape.trajectory(state, timesteps=3)
+        got = net.trajectory(state, timesteps=3)
         self.assertEqual([0, 0], state)
         self.assertEqual([[0, 0], [0, 1], [0, 1], [0, 1]], got)
 
-        got = landscape.trajectory(state, encode=False)
+        got = net.trajectory(state, encode=False)
         self.assertEqual([0, 0], state)
         self.assertEqual([[0, 0], [0, 1]], got)
 
-        got = landscape.trajectory(state, timesteps=3, encode=False)
+        got = net.trajectory(state, timesteps=3, encode=False)
         self.assertEqual([0, 0], state)
         self.assertEqual([[0, 0], [0, 1], [0, 1], [0, 1]], got)
 
-        got = landscape.trajectory(state, encode=True)
+        got = net.trajectory(state, encode=True)
         self.assertEqual([0, 0], state)
         self.assertEqual([0, 2], got)
 
-        got = landscape.trajectory(state, timesteps=3, encode=True)
+        got = net.trajectory(state, timesteps=3, encode=True)
         self.assertEqual([0, 0], state)
         self.assertEqual([0, 2, 2, 2], got)
 
         state = 0
-        got = landscape.trajectory(state)
+        got = net.trajectory(state)
         self.assertEqual([0, 2], got)
 
-        got = landscape.trajectory(state, timesteps=3)
+        got = net.trajectory(state, timesteps=3)
         self.assertEqual([0, 2, 2, 2], got)
 
-        got = landscape.trajectory(state, encode=True)
+        got = net.trajectory(state, encode=True)
         self.assertEqual([0, 2], got)
 
-        got = landscape.trajectory(state, timesteps=3, encode=True)
+        got = net.trajectory(state, timesteps=3, encode=True)
         self.assertEqual([0, 2, 2, 2], got)
 
-        got = landscape.trajectory(state, encode=False)
+        got = net.trajectory(state, encode=False)
         self.assertEqual([[0, 0], [0, 1]], got)
 
-        got = landscape.trajectory(state, timesteps=3, encode=False)
+        got = net.trajectory(state, timesteps=3, encode=False)
         self.assertEqual([[0, 0], [0, 1], [0, 1], [0, 1]], got)
 
     def test_trajectory_logicnetwork(self):
@@ -388,93 +329,89 @@ class TestLandscape(unittest.TestCase):
                             ((0, 2), {'01', '10', '11'}),
                             ((0, 1), {'11'})])
 
-        landscape = net.landscape()
-
         state = [0, 1, 0]
-        got = landscape.trajectory(state, encode=False)
+        got = net.trajectory(state, encode=False)
         self.assertEqual([0, 1, 0], state)
         self.assertEqual([[0, 1, 0], [1, 0, 0]], got)
 
-        got = landscape.trajectory(state, timesteps=3, encode=False)
+        got = net.trajectory(state, timesteps=3, encode=False)
         self.assertEqual([0, 1, 0], state)
         self.assertEqual([[0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]], got)
 
-        got = landscape.trajectory(state)
+        got = net.trajectory(state)
         self.assertEqual([0, 1, 0], state)
         self.assertEqual([[0, 1, 0], [1, 0, 0]], got)
 
-        got = landscape.trajectory(state, timesteps=3)
+        got = net.trajectory(state, timesteps=3)
         self.assertEqual([0, 1, 0], state)
         self.assertEqual([[0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]], got)
 
-        got = landscape.trajectory(state, encode=True)
+        got = net.trajectory(state, encode=True)
         self.assertEqual([0, 1, 0], state)
         self.assertEqual([2, 1], got)
 
-        got = landscape.trajectory(state, timesteps=3, encode=True)
+        got = net.trajectory(state, timesteps=3, encode=True)
         self.assertEqual([0, 1, 0], state)
         self.assertEqual([2, 1, 2, 1], got)
 
         state = 2
-        got = landscape.trajectory(state)
+        got = net.trajectory(state)
         self.assertEqual([2, 1], got)
 
-        got = landscape.trajectory(state, timesteps=3)
+        got = net.trajectory(state, timesteps=3)
         self.assertEqual([2, 1, 2, 1], got)
 
-        got = landscape.trajectory(state, encode=True)
+        got = net.trajectory(state, encode=True)
         self.assertEqual([2, 1], got)
 
-        got = landscape.trajectory(state, timesteps=3, encode=True)
+        got = net.trajectory(state, timesteps=3, encode=True)
         self.assertEqual([2, 1, 2, 1], got)
 
-        got = landscape.trajectory(state, encode=False)
+        got = net.trajectory(state, encode=False)
         self.assertEqual([[0, 1, 0], [1, 0, 0]], got)
 
-        got = landscape.trajectory(state, timesteps=3, encode=False)
+        got = net.trajectory(state, timesteps=3, encode=False)
         self.assertEqual([[0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]], got)
 
     def test_timeseries_too_short(self):
-        landscape = ECA(30, 3).landscape()
-        with self.assertRaises(ValueError):
-            landscape.timeseries(-1)
+        net = ECA(30, 3)
 
         with self.assertRaises(ValueError):
-            landscape.timeseries(0)
+            net.timeseries(-1)
+
+        with self.assertRaises(ValueError):
+            net.timeseries(0)
 
     def test_timeseries_eca(self):
         for size in [5, 7, 11]:
             rule = ECA(30, size)
-            landscape = rule.landscape()
             time = 10
-            series = landscape.timeseries(time)
+            series = rule.timeseries(time)
             self.assertEqual((size, 2**size, time + 1), series.shape)
             for index, state in enumerate(rule):
-                traj = landscape.trajectory(state, timesteps=time)
+                traj = rule.trajectory(state, timesteps=time)
                 for t, expect in enumerate(traj):
                     got = series[:, index, t]
                     self.assertTrue(np.array_equal(expect, got))
 
     def test_timeseries_wtnetworks(self):
         for net, size in [(s_pombe, 9), (s_cerevisiae, 11), (c_elegans, 8)]:
-            landscape = net.landscape()
             time = 10
-            series = landscape.timeseries(time)
+            series = net.timeseries(time)
             self.assertEqual((size, 2**size, time + 1), series.shape)
             for index, state in enumerate(net):
-                traj = landscape.trajectory(state, timesteps=time)
+                traj = net.trajectory(state, timesteps=time)
                 for t, expect in enumerate(traj):
                     got = series[:, index, t]
                     self.assertTrue(np.array_equal(expect, got))
 
     def test_basin_sizes(self):
         for net in [s_pombe, s_cerevisiae, c_elegans]:
-            landscape = net.landscape()
-            basins = landscape.basins
+            basins = net.basins
             histogram = [0] * (np.max(basins) + 1)
             for b in basins:
                 histogram[b] += 1
-            self.assertEqual(histogram, list(landscape.basin_sizes))
+            self.assertEqual(histogram, list(net.basin_sizes))
 
     def test_basin_entropy_eca(self):
         networks = [(ECA(30, 2), 1.500000),
@@ -501,104 +438,99 @@ class TestLandscape(unittest.TestCase):
 
     def test_graph_eca(self):
         for size in range(2, 7):
-            landscape = ECA(30, size).landscape()
-            g = landscape.transition_graph
-            self.assertEqual(landscape.volume, g.number_of_nodes())
-            self.assertEqual(landscape.volume, g.number_of_edges())
+            net = ECA(30, size)
+            g = net.transition_graph
+            self.assertEqual(net.volume, g.number_of_nodes())
+            self.assertEqual(net.volume, g.number_of_edges())
 
     def test_graph_wtnetworks(self):
         for net in [s_pombe, s_cerevisiae, c_elegans]:
-            landscape = net.landscape()
-            g = landscape.transition_graph
-            self.assertEqual(landscape.volume, g.number_of_nodes())
-            self.assertEqual(landscape.volume, g.number_of_edges())
+            g = net.transition_graph
+            self.assertEqual(net.volume, g.number_of_nodes())
+            self.assertEqual(net.volume, g.number_of_edges())
 
     def test_in_degree(self):
         for code in [30, 110, 21, 43]:
             for size in range(2, 7):
-                landscape = ECA(code, size).landscape()
-                in_degrees = np.empty(landscape.volume, dtype=np.int)
-                for i in range(landscape.volume):
+                net = ECA(code, size)
+                in_degrees = np.empty(net.volume, dtype=np.int)
+                for i in range(net.volume):
                     in_degrees[i] = np.count_nonzero(
-                        landscape.transitions == i)
-                self.assertEqual(list(in_degrees), list(landscape.in_degrees))
+                        net.transitions == i)
+                self.assertEqual(list(in_degrees), list(net.in_degrees))
 
         for net in [s_pombe, s_cerevisiae, c_elegans]:
-            landscape = net.landscape()
-            in_degrees = np.empty(landscape.volume, dtype=np.int)
-            for i in range(landscape.volume):
-                in_degrees[i] = np.count_nonzero(landscape.transitions == i)
-            self.assertEqual(list(in_degrees), list(landscape.in_degrees))
+            in_degrees = np.empty(net.volume, dtype=np.int)
+            for i in range(net.volume):
+                in_degrees[i] = np.count_nonzero(net.transitions == i)
+            self.assertEqual(list(in_degrees), list(net.in_degrees))
 
     def test_heights(self):
         for code in [30, 110, 21, 43]:
             for size in range(2, 7):
-                landscape = ECA(code, size).landscape()
-                heights = [0] * landscape.volume
-                for i in range(landscape.volume):
-                    b = landscape.basins[i]
+                net = ECA(code, size)
+                heights = [0] * net.volume
+                for i in range(net.volume):
+                    b = net.basins[i]
                     state = i
-                    while state not in landscape.attractors[b]:
+                    while state not in net.attractors[b]:
                         heights[i] += 1
-                        state = landscape.transitions[state]
-                self.assertEqual(heights, list(landscape.heights))
+                        state = net.transitions[state]
+                self.assertEqual(heights, list(net.heights))
 
         for net in [s_pombe, s_cerevisiae, c_elegans]:
-            landscape = net.landscape()
-            heights = [0] * landscape.volume
-            for i in range(landscape.volume):
-                b = landscape.basins[i]
+            heights = [0] * net.volume
+            for i in range(net.volume):
+                b = net.basins[i]
                 state = i
-                while state not in landscape.attractors[b]:
+                while state not in net.attractors[b]:
                     heights[i] += 1
-                    state = landscape.transitions[state]
-            self.assertEqual(heights, list(landscape.heights))
+                    state = net.transitions[state]
+            self.assertEqual(heights, list(net.heights))
 
     def test_attractor_lengths(self):
         for code in [30, 110, 21, 43]:
             for size in range(2, 7):
-                landscape = ECA(code, size).landscape()
-                lengths = list(map(len, landscape.attractors))
-                self.assertEqual(lengths, list(landscape.attractor_lengths))
+                net = ECA(code, size)
+                lengths = list(map(len, net.attractors))
+                self.assertEqual(lengths, list(net.attractor_lengths))
 
         for net in [s_pombe, s_cerevisiae, c_elegans]:
-            landscape = net.landscape()
-            lengths = list(map(len, landscape.attractors))
-            self.assertEqual(lengths, list(landscape.attractor_lengths))
+            lengths = list(map(len, net.attractors))
+            self.assertEqual(lengths, list(net.attractor_lengths))
 
     def test_recurrence_times(self):
         for code in [30, 110, 21, 43]:
             for size in range(2, 7):
-                landscape = ECA(code, size).landscape()
-                recurrence_times = [0] * landscape.volume
-                for i in range(landscape.volume):
-                    b = landscape.basins[i]
-                    recurrence_times[i] = landscape.heights[i] + \
-                        landscape.attractor_lengths[b] - 1
+                net = ECA(code, size)
+                recurrence_times = [0] * net.volume
+                for i in range(net.volume):
+                    b = net.basins[i]
+                    recurrence_times[i] = net.heights[i] + \
+                        net.attractor_lengths[b] - 1
                 self.assertEqual(recurrence_times, list(
-                    landscape.recurrence_times))
+                    net.recurrence_times))
 
         for net in [s_pombe, s_cerevisiae, c_elegans]:
-            landscape = net.landscape()
-            recurrence_times = [0] * landscape.volume
-            for i in range(landscape.volume):
-                b = landscape.basins[i]
-                recurrence_times[i] = landscape.heights[i] + \
-                    landscape.attractor_lengths[b] - 1
+            recurrence_times = [0] * net.volume
+            for i in range(net.volume):
+                b = net.basins[i]
+                recurrence_times[i] = net.heights[i] + \
+                    net.attractor_lengths[b] - 1
             self.assertEqual(recurrence_times, list(
-                landscape.recurrence_times))
+                net.recurrence_times))
 
     def test_landscape_data(self):
-        ca = ECA(30, size=5)
-        data_before_setup = ca.landscape_data
+        net = ECA(30, size=5)
+        data_before_setup = net.landscape_data
         self.assertEqual(data_before_setup.__dict__, {})
 
-        data_after_setup = ca.landscape().landscape_data
+        data_after_setup = net.landscape().landscape_data
         self.assertEqual(data_before_setup.__dict__, {})
         self.assertEqual(
             list(data_after_setup.__dict__.keys()), ['transitions'])
 
-        data_after_expound = ca.expound().landscape_data
+        data_after_expound = net.expound().landscape_data
         self.assertEqual(data_before_setup.__dict__, {})
         self.assertEqual(set(data_after_setup.__dict__.keys()), set([
             "transitions",

--- a/test/test_synchronous.py
+++ b/test/test_synchronous.py
@@ -19,26 +19,22 @@ class TestLandscape(unittest.TestCase):
         ca = ECA(30, 1)
 
         landscape = ca.landscape()
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(1, landscape.size)
         self.assertEqual([0, 0], list(landscape.transitions))
 
         ca.size = 2
         landscape = ca.landscape()
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([0, 1, 2, 0], list(landscape.transitions))
 
         ca.size = 3
         landscape = ca.landscape()
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(3, landscape.size)
         self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(landscape.transitions))
 
         ca.size = 10
         landscape = ca.landscape()
         trans = landscape.transitions
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(10, landscape.size)
         self.assertEqual(1024, len(trans))
         self.assertEqual([0, 515, 7, 517, 14, 525, 11,
@@ -49,51 +45,42 @@ class TestLandscape(unittest.TestCase):
     def test_transitions_eca_index(self):
         ca = ECA(30, 3)
         landscape = ca.landscape(index=1)
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(3, landscape.size)
         self.assertEqual([0, 3, 2, 1, 6, 5, 6, 5], list(landscape.transitions))
 
         landscape = ca.landscape(index=0)
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(3, landscape.size)
         self.assertEqual([0, 1, 3, 3, 5, 4, 6, 6], list(landscape.transitions))
 
         landscape = ca.landscape(index=None)
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(3, landscape.size)
         self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(landscape.transitions))
 
     def test_transitions_eca_pin(self):
         ca = ECA(30, 3)
         landscape = ca.landscape(pin=[1])
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(3, landscape.size)
         self.assertEqual([0, 5, 7, 3, 5, 4, 2, 2], list(landscape.transitions))
 
         landscape = ca.landscape(pin=[0])
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(3, landscape.size)
         self.assertEqual([0, 7, 6, 1, 6, 5, 2, 1], list(landscape.transitions))
 
         landscape = ca.landscape(pin=None)
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(3, landscape.size)
         self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(landscape.transitions))
 
     def test_transitions_eca_values(self):
         ca = ECA(30, 3)
         landscape = ca.landscape(values={0: 1})
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(3, landscape.size)
         self.assertEqual([1, 7, 7, 1, 7, 5, 3, 1], list(landscape.transitions))
 
         landscape = ca.landscape(values={1: 0})
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(3, landscape.size)
         self.assertEqual([0, 5, 5, 1, 5, 4, 0, 0], list(landscape.transitions))
 
         landscape = ca.landscape(values={})
-        # self.assertEqual(ca, landscape.network)
         self.assertEqual(3, landscape.size)
         self.assertEqual([0, 7, 7, 1, 7, 4, 2, 0], list(landscape.transitions))
 
@@ -105,7 +92,6 @@ class TestLandscape(unittest.TestCase):
         )
 
         landscape = net.landscape()
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
 
@@ -117,17 +103,14 @@ class TestLandscape(unittest.TestCase):
         )
 
         landscape = net.landscape(index=1)
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
 
         landscape = net.landscape(index=0)
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([0, 1, 2, 3], list(landscape.transitions))
 
         landscape = net.landscape(index=None)
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
 
@@ -139,17 +122,14 @@ class TestLandscape(unittest.TestCase):
         )
 
         landscape = net.landscape(pin=[1])
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([0, 1, 2, 3], list(landscape.transitions))
 
         landscape = net.landscape(pin=[0])
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
 
         landscape = net.landscape(pin=None)
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
 
@@ -161,27 +141,21 @@ class TestLandscape(unittest.TestCase):
         )
 
         landscape = net.landscape(values={0: 1})
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([3, 1, 3, 3], list(landscape.transitions))
 
         landscape = net.landscape(values={1: 0})
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([0, 1, 0, 1], list(landscape.transitions))
 
         landscape = net.landscape(values={})
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([2, 1, 2, 3], list(landscape.transitions))
-
-        # Add more test for different thetas?
 
     def test_transitions_logicnetwork(self):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
 
         landscape = net.landscape()
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([1, 3, 1, 3], list(landscape.transitions))
 
@@ -189,17 +163,14 @@ class TestLandscape(unittest.TestCase):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
 
         landscape = net.landscape(index=1)
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([0, 3, 0, 3], list(landscape.transitions))
 
         landscape = net.landscape(index=0)
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([1, 1, 3, 3], list(landscape.transitions))
 
         landscape = net.landscape(index=None)
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([1, 3, 1, 3], list(landscape.transitions))
 
@@ -207,17 +178,14 @@ class TestLandscape(unittest.TestCase):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
 
         landscape = net.landscape(pin=[1])
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([1, 1, 3, 3], list(landscape.transitions))
 
         landscape = net.landscape(pin=[0])
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([0, 3, 0, 3], list(landscape.transitions))
 
         landscape = net.landscape(pin=None)
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([1, 3, 1, 3], list(landscape.transitions))
 
@@ -225,17 +193,14 @@ class TestLandscape(unittest.TestCase):
         net = LogicNetwork([((1,), {'0', '1'}), ((0,), {'1'})])
 
         landscape = net.landscape(values={0: 1})
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([1, 3, 1, 3], list(landscape.transitions))
 
         landscape = net.landscape(values={1: 0})
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([1, 1, 1, 1], list(landscape.transitions))
 
         landscape = net.landscape(values={})
-        # self.assertEqual(net, landscape.network)
         self.assertEqual(2, landscape.size)
         self.assertEqual([1, 3, 1, 3], list(landscape.transitions))
 
@@ -243,7 +208,6 @@ class TestLandscape(unittest.TestCase):
 
     def test_transitions_spombe(self):
         landscape = s_pombe.landscape()
-        # self.assertEqual(s_pombe, landscape.network)
         self.assertEqual(9, landscape.size)
         trans = landscape.transitions
         self.assertEqual(512, len(trans))
@@ -253,8 +217,6 @@ class TestLandscape(unittest.TestCase):
                           336, 464, 464], list(trans[-10:]))
 
     def test_is_state_space(self):
-        # self.assertTrue(issubclass(Landscape, StateSpace))
-
         landscape = s_pombe.landscape()
         self.assertEqual(list(s_pombe), list(landscape))
         self.assertEqual([s_pombe.encode(state) for state in s_pombe],
@@ -515,37 +477,27 @@ class TestLandscape(unittest.TestCase):
             self.assertEqual(histogram, list(landscape.basin_sizes))
 
     def test_basin_entropy_eca(self):
-        networks = [(ECA(30, 2), 1.500000, 0.451545),
-                    (ECA(30, 3), 0.000000, 0.000000),
-                    (ECA(30, 4), 1.186278, 0.357105),
-                    (ECA(30, 5), 0.337290, 0.101534),
-                    (ECA(30, 6), 0.231872, 0.069801),
-                    (ECA(110, 2), 0.000000, 0.000000),
-                    (ECA(110, 3), 0.000000, 0.000000),
-                    (ECA(110, 4), 1.561278, 0.469992),
-                    (ECA(110, 5), 0.000000, 0.000000),
-                    (ECA(110, 6), 1.469012, 0.442217)]
+        networks = [(ECA(30, 2), 1.500000),
+                    (ECA(30, 3), 0.000000),
+                    (ECA(30, 4), 1.186278),
+                    (ECA(30, 5), 0.337290),
+                    (ECA(30, 6), 0.231872),
+                    (ECA(110, 2), 0.000000),
+                    (ECA(110, 3), 0.000000),
+                    (ECA(110, 4), 1.561278),
+                    (ECA(110, 5), 0.000000),
+                    (ECA(110, 6), 1.469012)]
 
-        for net, base2, base10 in networks:
-            landscape = net.landscape()
-            self.assertAlmostEqual(base2, landscape.basin_entropy(), places=6)
-            self.assertAlmostEqual(
-                base2, landscape.basin_entropy(base=2), places=6)
-            self.assertAlmostEqual(
-                base10, landscape.basin_entropy(base=10), places=6)
+        for net, entropy in networks:
+            self.assertAlmostEqual(entropy, net.basin_entropy, places=6)
 
     def test_basin_entropy_wtnetwork(self):
-        networks = [(s_pombe, 1.221889, 0.367825),
-                    (s_cerevisiae, 0.783858, 0.235965),
-                    (c_elegans, 0.854267, 0.257160)]
+        networks = [(s_pombe, 1.221889),
+                    (s_cerevisiae, 0.783858),
+                    (c_elegans, 0.854267)]
 
-        for net, base2, base10 in networks:
-            landscape = net.landscape()
-            self.assertAlmostEqual(base2, landscape.basin_entropy(), places=6)
-            self.assertAlmostEqual(
-                base2, landscape.basin_entropy(base=2), places=6)
-            self.assertAlmostEqual(
-                base10, landscape.basin_entropy(base=10), places=6)
+        for net, entropy in networks:
+            self.assertAlmostEqual(entropy, net.basin_entropy, places=6)
 
     def test_graph_eca(self):
         for size in range(2, 7):
@@ -635,3 +587,38 @@ class TestLandscape(unittest.TestCase):
                     landscape.attractor_lengths[b] - 1
             self.assertEqual(recurrence_times, list(
                 landscape.recurrence_times))
+
+    def test_landscape_data(self):
+        ca = ECA(30, size=5)
+        data_before_setup = ca.landscape_data
+        self.assertEqual(data_before_setup.__dict__, {})
+
+        data_after_setup = ca.landscape().landscape_data
+        self.assertEqual(data_before_setup.__dict__, {})
+        self.assertEqual(
+            list(data_after_setup.__dict__.keys()), ['transitions'])
+
+        data_after_expound = ca.expound().landscape_data
+        self.assertEqual(data_before_setup.__dict__, {})
+        self.assertEqual(set(data_after_setup.__dict__.keys()), set([
+            "transitions",
+            "basins",
+            "basin_sizes",
+            "attractors",
+            "attractor_lengths",
+            "in_degrees",
+            "heights",
+            "recurrence_times",
+            "basin_entropy"
+        ]))
+        self.assertEqual(set(data_after_expound.__dict__.keys()), set([
+            "transitions",
+            "basins",
+            "basin_sizes",
+            "attractors",
+            "attractor_lengths",
+            "in_degrees",
+            "heights",
+            "recurrence_times",
+            "basin_entropy"
+        ]))


### PR DESCRIPTION
This pull request does the following:

* It removes any reference to `LandscapeMixin` internal variables from `Network`
* Creates the `LandscapeMixin.landscape_data` property
* Add basin entropy to `LandscapeData`
* Renames `LandscapeMixin.__expound` to `LandscapeMixin.expound`
* Creates the `clear_landscape` method (which resets the internal landscape data)
* Calls `clear_landscape` in the `ECA` and `RewiredECA` property setters
* Improves test coverage a smidge