### PR TITLE
Resolve #194

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fixed #194

--- a/neet/network.py
+++ b/neet/network.py
@@ -340,17 +340,21 @@ class Network(LandscapeMixin, StateSpace):
         :return: a :class:`networkx.DiGraph` object
         """
         if labels == 'indices':
-            edges = [(i, j) for i in range(self.size) for j in self.neighbors_out(i)]
+            nodes = range(self.size)
+            edges = [(i, j) for i in nodes for j in self.neighbors_out(i)]
         elif labels == 'names' and self.names is not None:
-            names = self.names
-            edges = [(names[i], names[j]) for i in range(self.size) for j in self.neighbors_out(i)]
+            nodes = self.names
+            edges = [(nodes[i], nodes[j]) for i in range(self.size) for j in self.neighbors_out(i)]
         elif labels == 'names' and self.names is None:
             raise ValueError("network nodes do not have names")
         else:
             raise ValueError("labels argument must be 'names' or 'indices', got {}".format(labels))
 
         kwargs.update(self.metadata)
-        return nx.DiGraph(edges, **kwargs)
+        g = nx.DiGraph(**kwargs)
+        g.add_nodes_from(nodes)
+        g.add_edges_from(edges)
+        return g
 
     def draw_network_graph(self, graphkwargs={}, pygraphkwargs={}):
         """

--- a/test/boolean/test_logic.py
+++ b/test/boolean/test_logic.py
@@ -344,3 +344,12 @@ class TestLogicNetwork(unittest.TestCase):
         nx_net = net.network_graph(labels='indices')
 
         self.assertEqual(nx_net.graph['name'], net.metadata['name'])
+
+    def test_network_graph_has_all_nodes(self):
+        net = LogicNetwork([((), set())])
+        g = net.network_graph()
+        self.assertEqual(g.number_of_nodes(), net.size)
+
+        net = LogicNetwork([((), set()), ((2,), {'0'}), ((1,), {'1'})])
+        g = net.network_graph()
+        self.assertEqual(g.number_of_nodes(), net.size)

--- a/test/boolean/test_logic.py
+++ b/test/boolean/test_logic.py
@@ -337,14 +337,10 @@ class TestLogicNetwork(unittest.TestCase):
         with self.assertRaises(ValueError):
             net.network_graph(labels='names')
 
-    def test_to_networkx_metadata(self):
+    def test_network_graph_metadata(self):
         net = LogicNetwork([((0,), {'0'})])
         net.metadata['name'] = 'net_name'
 
         nx_net = net.network_graph(labels='indices')
 
         self.assertEqual(nx_net.graph['name'], net.metadata['name'])
-
-    # def test_draw(self):
-    #     net = bnet.LogicNetwork([((0,), {'0'})])
-    #     draw(net,labels='indices')

--- a/test/boolean/test_wtnetwork.py
+++ b/test/boolean/test_wtnetwork.py
@@ -722,7 +722,7 @@ class TestWTNetwork(unittest.TestCase):
         with self.assertRaises(ValueError):
             net.network_graph(labels='names')
 
-    def test_to_networkx_metadata(self):
+    def test_network_graph_metadata(self):
         from neet.boolean.examples import s_pombe
 
         nx_net = s_pombe.network_graph(labels='indices')


### PR DESCRIPTION
## Description

Networks were losing lone nodes when convert the network `networkx.DiGraph`. This was fixed by explicitly adding all nodes to the network before adding edges. The reason this was necessary is the `networkx.DiGraph` initializer only adds endpoint nodes when you construct it with a list of edges. Since lone nodes have no edges, they were not included.

Fixes #194

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Create a LogicNetwork with a single node and no edges. The resulting DiGraph has 1 node
- [x] Create a LogicNetwork with two connected nodes and one lone node. The resulting DiGraph as 3 nodes

We have not tested this for `WTNetwork` on account of #193.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added appropriate labels to this pull request
- [X] This is a notable change, and I've added it to CHANGELOG.md
